### PR TITLE
fix: primitive() and enum validation now correctly handle null

### DIFF
--- a/src/validators/__tests__/primitive.spec.ts
+++ b/src/validators/__tests__/primitive.spec.ts
@@ -1,4 +1,99 @@
-// TODO: add tests
-describe.skip('primitive', () => {
-    it.skip('should validate any primitive value ', () => {})
+import { primitive } from '../schema/primitive.ts'
+
+describe('primitive', () => {
+	const schema = primitive()
+	const nonPrimitives = [
+		{},
+		[],
+		() => void 0,
+		() => void 0,
+		class {},
+		new Date(),
+		/a/,
+		/a/,
+		new Error(),
+		new Map(),
+		new Set(),
+		new WeakMap(),
+		new WeakSet(),
+		new ArrayBuffer(2),
+		new Int8Array(),
+		new Uint8Array(),
+		new Uint8ClampedArray(),
+		new Int16Array(),
+		new Uint16Array(),
+		new Int32Array(),
+		new Uint32Array(),
+		new Float32Array(),
+		new Float64Array(),
+		new BigInt64Array(),
+		new BigUint64Array(),
+		new Promise(() => void 0),
+		Promise.resolve(),
+		Promise.reject().catch(r => r),
+		new Proxy({}, {}),
+	]
+
+	it('should return true if value is null', () => {
+		expect(schema(null)).toBe(true)
+	})
+
+	it('should return true if value is undefined', () => {
+		expect(schema(undefined)).toBe(true)
+	})
+
+	it('should return true if value is a string', () => {
+		expect(schema('hello')).toBe(true)
+	})
+
+	it('should return true if value is a number', () => {
+		expect(schema(42)).toBe(true)
+	})
+
+	it('should return true if value is a bigint', () => {
+		expect(schema(BigInt(9007199254740991))).toBe(true)
+	})
+
+	it('should return true if value is a boolean', () => {
+		expect(schema(true)).toBe(true)
+		expect(schema(false)).toBe(true)
+	})
+
+	it('should return true if value is a symbol', () => {
+		expect(schema(Symbol())).toBe(true)
+	})
+
+	it('should return false if value is not a primitive', () => {
+		for (const value of nonPrimitives) expect(schema(value)).toBe(false)
+	})
+
+	it('should have an optional method embedded in the schema', () => {
+		expect(primitive()).toHaveProperty('optional')
+		expect(typeof primitive().optional).toBe('function')
+
+		// biome-ignore lint/nursery/noShadow: callback destructuring — name matches outer scope intentionally
+		const schema = primitive().optional()
+
+		expect(typeof schema).toBe('function')
+	})
+
+	it('should return true if value is null or undefined when optional', () => {
+		// biome-ignore lint/nursery/noShadow: callback destructuring — name matches outer scope intentionally
+		const schema = primitive().optional()
+
+		expect(schema(null)).toBe(true)
+		expect(schema(undefined)).toBe(true)
+	})
+
+	it('should return false if value is not a primitive when optional', () => {
+		// biome-ignore lint/nursery/noShadow: callback destructuring — name matches outer scope intentionally
+		const schema = primitive().optional()
+
+		for (const value of nonPrimitives) expect(schema(value)).toBe(false)
+	})
+
+	it('should have a validator method embedded in the schema', () => {
+		expect(primitive()).toHaveProperty('validator')
+		expect(typeof primitive().validator).toBe('function')
+	})
 })

--- a/src/validators/schema/helpers/validate/validateDefault.ts
+++ b/src/validators/schema/helpers/validate/validateDefault.ts
@@ -64,8 +64,8 @@ function validateDefaultInner(
         case 'tuple':
             validateDefaultTuple(ctx, validate, mustNotThrowCtx)
             break
-        case 'primitive':
-            if (!(Generics.Primitives as readonly string[]).includes(typeof ctx.arg))
+	case 'primitive':
+		if (ctx.arg !== null && !(Generics.Primitives as readonly string[]).includes(typeof ctx.arg))
                 ctx.pushNewError({
                     message: getValidatorMessage(ctx.schema, `Value must be a primitive`),
                     context: {
@@ -186,7 +186,7 @@ function validateDefaultEnum(
     if (metadata.types.length < 2)
         throw new TypeError('An enum schema must have at least two values to match')
 
-    if (!(Generics.Primitives as readonly string[]).includes(typeof ctx.arg))
+	if (ctx.arg !== null && !(Generics.Primitives as readonly string[]).includes(typeof ctx.arg))
         ctx.pushNewError({
             message: getValidatorMessage(ctx.schema, `Value must be a primitive`),
             context: {

--- a/src/validators/schema/primitive.ts
+++ b/src/validators/schema/primitive.ts
@@ -17,7 +17,7 @@ import { validateCustomRules } from './helpers/validateCustomRules.ts'
 
 function _fn(): TypeGuard<Generics.PrimitiveType> {
     const guard = (arg: unknown): arg is Generics.PrimitiveType =>
-        branchIfOptional(arg, []) || (Generics.Primitives as readonly string[]).includes(typeof arg)
+        branchIfOptional(arg, []) || arg === null || (Generics.Primitives as readonly string[]).includes(typeof arg)
 
     return setStructMetadata(
         { type: 'primitive', schema: guard, optional: false } as V3.PrimitiveStruct,


### PR DESCRIPTION
## Summary

Fixes #31

The `primitive()` schema guard and `validateDefault` both used `Generics.Primitives.includes(typeof arg)` to check if a value is a primitive. Since `typeof null === "object"` (not `"null"`), `null` was never matched despite being part of the `PrimitiveType` union.

## Changes

### Root cause fix — `src/validators/schema/primitive.ts`
Added explicit `arg === null` check before the `typeof` check in the guard:
```ts
branchIfOptional(arg, []) || arg === null || (Generics.Primitives as readonly string[]).includes(typeof arg)
```
This mirrors the pattern used in `asNull.ts` which already checks `arg === null` directly.

### Same structural bug in validator — `src/validators/schema/helpers/validate/validateDefault.ts`
The `validateDefaultInner` function had the same `typeof`-only check in two places:

1. **`primitive` case (line 68)** — Added `ctx.arg !== null &&` guard before the `typeof` check
2. **`enum` case (line 189)** — Same fix applied. This was an additional bug with the same root cause: `asEnum` schemas containing `null` values would fail validation because the enum case in `validateDefault` rejects non-`typeof`-matchable values before checking enum members.

Note: The `asEnum.ts` guard itself delegates to `primitive()`, so it is automatically fixed by the `primitive.ts` change. The separate fix was only needed in `validateDefault.ts`.

### Tests — `src/validators/__tests__/primitive.spec.ts`
Replaced the skipped stub with a full test suite covering:
- All primitive types including `null` (the core bug)
- Non-primitive rejection
- `optional()` variant
- `validator()` method existence

## Reproduction (before fix)
```ts
primitive()(null)       // false — now true
primitive().optional()(null)  // false — now true
```