### PR TITLE
feat(build): improve Socket.dev supply chain security score

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,6 @@
-!.env.example
 .env
 .env.*
+.env.example
 .github
 .history
 .jest.*

--- a/package.json
+++ b/package.json
@@ -56,24 +56,31 @@
         "url": "https://github.com/SrHenry/type-utils/issues"
     },
     "homepage": "https://github.com/SrHenry/type-utils#readme",
-    "dependencies": {
-        "@types/node": "^25.6.2",
-        "typescript": "6.0.3"
-    },
-    "devDependencies": {
-	"@biomejs/biome": "^2.4.15",
-	"@vitest/coverage-v8": "^3.2.1",
-	"vitest": "^3.2.1",
-        "madge": "^8.0.0",
-        "prettier": "^3.8.3",
-        "run-script-os": "^1.1.6",
-	"ts-node": "^10.9.2",
-        "tsx": "^4.21.0",
-        "typedoc": "^0.28.19",
-        "uuid": "^14.0.0",
-        "webpack": "^5.106.2",
-        "webpack-cli": "^7.0.2"
-    },
+"dependencies": {},
+  "peerDependencies": {
+    "typescript": ">=5.8"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.15",
+    "@types/node": "^25.6.2",
+    "@vitest/coverage-v8": "^3.2.1",
+    "typescript": "6.0.3",
+    "vitest": "^3.2.1",
+    "madge": "^8.0.0",
+    "prettier": "^3.8.3",
+    "run-script-os": "^1.1.6",
+    "ts-node": "^10.9.2",
+    "tsx": "^4.21.0",
+    "typedoc": "^0.28.19",
+    "uuid": "^14.0.0",
+    "webpack": "^5.106.2",
+    "webpack-cli": "^7.0.2"
+  },
 	"resolutions": {
 		"glob/minimatch": "^9.0.7",
 		"typedoc/minimatch": "^9.0.7",

--- a/src/validators/__tests__/primitive.spec.ts
+++ b/src/validators/__tests__/primitive.spec.ts
@@ -1,99 +1,99 @@
 import { primitive } from '../schema/primitive.ts'
 
 describe('primitive', () => {
-	const schema = primitive()
-	const nonPrimitives = [
-		{},
-		[],
-		() => void 0,
-		() => void 0,
-		class {},
-		new Date(),
-		/a/,
-		/a/,
-		new Error(),
-		new Map(),
-		new Set(),
-		new WeakMap(),
-		new WeakSet(),
-		new ArrayBuffer(2),
-		new Int8Array(),
-		new Uint8Array(),
-		new Uint8ClampedArray(),
-		new Int16Array(),
-		new Uint16Array(),
-		new Int32Array(),
-		new Uint32Array(),
-		new Float32Array(),
-		new Float64Array(),
-		new BigInt64Array(),
-		new BigUint64Array(),
-		new Promise(() => void 0),
-		Promise.resolve(),
-		Promise.reject().catch(r => r),
-		new Proxy({}, {}),
-	]
+    const schema = primitive()
+    const nonPrimitives = [
+        {},
+        [],
+        () => void 0,
+        () => void 0,
+        class {},
+        new Date(),
+        /a/,
+        /a/,
+        new Error(),
+        new Map(),
+        new Set(),
+        new WeakMap(),
+        new WeakSet(),
+        new ArrayBuffer(2),
+        new Int8Array(),
+        new Uint8Array(),
+        new Uint8ClampedArray(),
+        new Int16Array(),
+        new Uint16Array(),
+        new Int32Array(),
+        new Uint32Array(),
+        new Float32Array(),
+        new Float64Array(),
+        new BigInt64Array(),
+        new BigUint64Array(),
+        new Promise(() => void 0),
+        Promise.resolve(),
+        Promise.reject().catch(r => r),
+        new Proxy({}, {}),
+    ]
 
-	it('should return true if value is null', () => {
-		expect(schema(null)).toBe(true)
-	})
+    it('should return true if value is null', () => {
+        expect(schema(null)).toBe(true)
+    })
 
-	it('should return true if value is undefined', () => {
-		expect(schema(undefined)).toBe(true)
-	})
+    it('should return true if value is undefined', () => {
+        expect(schema(undefined)).toBe(true)
+    })
 
-	it('should return true if value is a string', () => {
-		expect(schema('hello')).toBe(true)
-	})
+    it('should return true if value is a string', () => {
+        expect(schema('hello')).toBe(true)
+    })
 
-	it('should return true if value is a number', () => {
-		expect(schema(42)).toBe(true)
-	})
+    it('should return true if value is a number', () => {
+        expect(schema(42)).toBe(true)
+    })
 
-	it('should return true if value is a bigint', () => {
-		expect(schema(BigInt(9007199254740991))).toBe(true)
-	})
+    it('should return true if value is a bigint', () => {
+        expect(schema(BigInt(9007199254740991))).toBe(true)
+    })
 
-	it('should return true if value is a boolean', () => {
-		expect(schema(true)).toBe(true)
-		expect(schema(false)).toBe(true)
-	})
+    it('should return true if value is a boolean', () => {
+        expect(schema(true)).toBe(true)
+        expect(schema(false)).toBe(true)
+    })
 
-	it('should return true if value is a symbol', () => {
-		expect(schema(Symbol())).toBe(true)
-	})
+    it('should return true if value is a symbol', () => {
+        expect(schema(Symbol())).toBe(true)
+    })
 
-	it('should return false if value is not a primitive', () => {
-		for (const value of nonPrimitives) expect(schema(value)).toBe(false)
-	})
+    it('should return false if value is not a primitive', () => {
+        for (const value of nonPrimitives) expect(schema(value)).toBe(false)
+    })
 
-	it('should have an optional method embedded in the schema', () => {
-		expect(primitive()).toHaveProperty('optional')
-		expect(typeof primitive().optional).toBe('function')
+    it('should have an optional method embedded in the schema', () => {
+        expect(primitive()).toHaveProperty('optional')
+        expect(typeof primitive().optional).toBe('function')
 
-		// biome-ignore lint/nursery/noShadow: callback destructuring — name matches outer scope intentionally
-		const schema = primitive().optional()
+        // biome-ignore lint/nursery/noShadow: callback destructuring — name matches outer scope intentionally
+        const schema = primitive().optional()
 
-		expect(typeof schema).toBe('function')
-	})
+        expect(typeof schema).toBe('function')
+    })
 
-	it('should return true if value is null or undefined when optional', () => {
-		// biome-ignore lint/nursery/noShadow: callback destructuring — name matches outer scope intentionally
-		const schema = primitive().optional()
+    it('should return true if value is null or undefined when optional', () => {
+        // biome-ignore lint/nursery/noShadow: callback destructuring — name matches outer scope intentionally
+        const schema = primitive().optional()
 
-		expect(schema(null)).toBe(true)
-		expect(schema(undefined)).toBe(true)
-	})
+        expect(schema(null)).toBe(true)
+        expect(schema(undefined)).toBe(true)
+    })
 
-	it('should return false if value is not a primitive when optional', () => {
-		// biome-ignore lint/nursery/noShadow: callback destructuring — name matches outer scope intentionally
-		const schema = primitive().optional()
+    it('should return false if value is not a primitive when optional', () => {
+        // biome-ignore lint/nursery/noShadow: callback destructuring — name matches outer scope intentionally
+        const schema = primitive().optional()
 
-		for (const value of nonPrimitives) expect(schema(value)).toBe(false)
-	})
+        for (const value of nonPrimitives) expect(schema(value)).toBe(false)
+    })
 
-	it('should have a validator method embedded in the schema', () => {
-		expect(primitive()).toHaveProperty('validator')
-		expect(typeof primitive().validator).toBe('function')
-	})
+    it('should have a validator method embedded in the schema', () => {
+        expect(primitive()).toHaveProperty('validator')
+        expect(typeof primitive().validator).toBe('function')
+    })
 })

--- a/src/validators/schema/helpers/validate/validateDefault.ts
+++ b/src/validators/schema/helpers/validate/validateDefault.ts
@@ -64,8 +64,11 @@ function validateDefaultInner(
         case 'tuple':
             validateDefaultTuple(ctx, validate, mustNotThrowCtx)
             break
-	case 'primitive':
-		if (ctx.arg !== null && !(Generics.Primitives as readonly string[]).includes(typeof ctx.arg))
+        case 'primitive':
+            if (
+                ctx.arg !== null &&
+                !(Generics.Primitives as readonly string[]).includes(typeof ctx.arg)
+            )
                 ctx.pushNewError({
                     message: getValidatorMessage(ctx.schema, `Value must be a primitive`),
                     context: {
@@ -186,7 +189,7 @@ function validateDefaultEnum(
     if (metadata.types.length < 2)
         throw new TypeError('An enum schema must have at least two values to match')
 
-	if (ctx.arg !== null && !(Generics.Primitives as readonly string[]).includes(typeof ctx.arg))
+    if (ctx.arg !== null && !(Generics.Primitives as readonly string[]).includes(typeof ctx.arg))
         ctx.pushNewError({
             message: getValidatorMessage(ctx.schema, `Value must be a primitive`),
             context: {

--- a/src/validators/schema/primitive.ts
+++ b/src/validators/schema/primitive.ts
@@ -18,7 +18,9 @@ import { validateCustomRules } from './helpers/validateCustomRules.ts'
 
 function _fn(): TypeGuard<Generics.PrimitiveType> {
     const guard = (arg: unknown): arg is Generics.PrimitiveType =>
-        branchIfOptional(arg, []) || arg === null || (Generics.Primitives as readonly string[]).includes(typeof arg)
+        branchIfOptional(arg, []) ||
+        arg === null ||
+        (Generics.Primitives as readonly string[]).includes(typeof arg)
 
     return setStructMetadata(
         { type: 'primitive', schema: guard, optional: false } as V3.PrimitiveStruct,


### PR DESCRIPTION
## Summary

Restructure dependency declarations and update `.npmignore` to resolve 3 of 4 Socket.dev supply chain security alerts on `@srhenry/type-utils@0.8.0`.

## Changes

### `package.json` — Dependency restructuring
- **Move `typescript`** from `dependencies` → `devDependencies` + `peerDependencies` (`>=5.8`, optional)
- **Move `@types/node`** from `dependencies` → `devDependencies`
- Production dependency count goes from 2 → 0

### `.npmignore` — Exclude `.env.example`
- Remove `!.env.example` (previously explicitly included)
- Add `.env.example` to exclusion list (contains release harness config, not relevant to npm consumers)

## Socket.dev alerts resolved

| Alert | Severity | Resolution |
|-------|----------|------------|
| Dependency URL strings (`typescript`) | Supply Chain Risk | Resolved — no longer a prod dep |
| Dependency URL strings (`@types/node`) | Supply Chain Risk | Resolved — no longer a prod dep |
| Non-permissive License (`W3C FSA` in `typescript` ThirdPartyNoticeText.txt) | License | Resolved — no longer a prod dep |

## Socket.dev alerts NOT resolved

| Alert | Severity | Reason |
|-------|----------|--------|
| Package URL strings (`String.email`) | Supply Chain Risk | False positive — `String.email` is a namespaced rule identifier, not a URL. No code change to appease a scanner heuristic. |

## Verification

- `yarn build:clean` — passes
- `yarn test` — 348 tests pass
- `yarn tsc -p tsconfig.json --noEmit` — typecheck passes
- `yarn check:fix` — lint + format passes
- `npm pack --dry-run` — confirms 0 production dependencies, `.env.example` excluded

## Peer dependency rationale

- `typescript >=5.8` is the minimum compatible version (required by `stableTypeOrdering: true` in tsconfig.json, introduced in TS 5.8)
- Marked `optional: true` so consumers without TypeScript are not penalized — the package ships pre-compiled JS + `.d.ts` files

## Follow-up

After merging and publishing, verify whether the 3rd dependency URL alert persists. If it does, investigate in a follow-up PR.