### PR TITLE
docs(AGENTS): mandate commit author clarification with default owner identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,8 +108,8 @@ Scopes: `schema`, `validator`, `build`, `README`, `pipeline`, `types`, etc.
 
 Before making any commit, the AI harness **must** clarify the commit author identity:
 
-- **Default author**: The repository owner — the AI harness must ask the user to confirm the author identity before the first commit in a session, unless already specified earlier in the conversation
-- **Verification step**: Before the first commit, check the worktree's `user.name` and `user.email` (`git config user.name` / `git config user.email`) — if they look like placeholder values (e.g., `Test`, `test@test.com`), stop and ask the user for the correct identity before committing
+- **Default author**: The local then global git config of the root worktree (i.e., `git config user.name` / `git config user.email` resolved from the main repo checkout, not the ephemeral worktree) — the AI harness must ask the user to confirm the author identity before the first commit in a session, unless already specified earlier in the conversation
+- **Verification step**: Before the first commit, check the resolved `user.name` and `user.email` — if they look like placeholder values (e.g., `Test`, `test@test.com`), stop and ask the user for the correct identity before committing
 - **Override**: If the user explicitly requests a different author (e.g., a co-author, bot identity, or different email), use that instead — but never assume an alternate identity without explicit direction
 - **GPG signing**: When the author identity is confirmed, commits should be GPG-signed (`-S` / `--gpg-sign`) with the key matching the author's email
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,15 @@ Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `style`, `deprecate`, `merge`
 
 Scopes: `schema`, `validator`, `build`, `README`, `pipeline`, `types`, etc.
 
+### Commit Authoring
+
+Before making any commit, the AI harness **must** clarify the commit author identity:
+
+- **Default author**: The repository owner — the AI harness must ask the user to confirm the author identity before the first commit in a session, unless already specified earlier in the conversation
+- **Verification step**: Before the first commit, check the worktree's `user.name` and `user.email` (`git config user.name` / `git config user.email`) — if they look like placeholder values (e.g., `Test`, `test@test.com`), stop and ask the user for the correct identity before committing
+- **Override**: If the user explicitly requests a different author (e.g., a co-author, bot identity, or different email), use that instead — but never assume an alternate identity without explicit direction
+- **GPG signing**: When the author identity is confirmed, commits should be GPG-signed (`-S` / `--gpg-sign`) with the key matching the author's email
+
 ### Branch Naming
 
 | Pattern | Use |


### PR DESCRIPTION
## Summary

Adds a **Commit Authoring** subsection to AGENTS.md under "Commit Style" that requires AI harnesses to clarify the commit author identity before making any commit in a session.

### Rules added
- **Default author**: Repository owner — AI must ask the user to confirm before the first commit
- **Verification step**: Check `git config user.name`/`user.email` for placeholder values (e.g. `Test`, `test@test.com`) and stop if detected
- **Override**: Use a different identity only when the user explicitly requests it
- **GPG signing**: Sign commits with the key matching the confirmed author email

### Why
The previous PR (#34) had commits authored as `Test <test@test.com>` due to a local git config issue in the root worktree. This went unnoticed because no rule enforced author identity verification. The new section prevents this class of problem generically — no hardcoded identity, usable by any contributor.

### Test plan
- [x] `yarn check:fix` passes (lint + format)
- [x] `yarn test` passes
- [x] `yarn tsc -p tsconfig.json --noEmit` passes
- [ ] Manual: verify that a fresh session reads the new rules and asks for author identity before committing