### PR TITLE
fix(release): ANSI escape, harness adapter abstraction, and parallel test runner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # Release automation harness
+# Supported adapters: opencode
 RELEASE_HARNESS=opencode
 RELEASE_HARNESS_MODEL=nvidia/z-ai/glm-5.1
 RELEASE_HARNESS_ARGS=--dangerously-skip-permissions

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,16 @@
 
 ## Release pipeline (`workflows/release/release.sh`)
 
+### Harness adapters
+
+- Implement `claude` adapter (Claude Code CLI)
+- Implement `codex` adapter (OpenAI Codex CLI)
+- Implement `hermes` adapter
+- Implement `openclaw` adapter
+- Implement `antigravity` adapter
+- Register each new adapter name in `_HARNESS_ADAPTERS` and `_harness_adapter_name()`
+- Add adapter-specific env vars to `.env.example` (e.g. CLAUDE_CODE_MODEL)
+
 ### Merge & conflict handling
 
 - `--auto-merge` with conflict detection and resolution hints

--- a/workflows/__test__/run-tests.sh
+++ b/workflows/__test__/run-tests.sh
@@ -2,7 +2,7 @@
 # run-tests.sh — Global test orchestrator for workflows scripts
 # Discovers and runs all test files matching workflows/**/__test__/test-*.sh
 # Usage: ./workflows/__test__/run-tests.sh [test-file-subpath...]
-# No args: discovers and runs all test files
+# No args: discovers and runs all test files in parallel (bounded by CPU cores)
 # With args: runs only the specified test files (subpaths relative to workflows/)
 
 set -u
@@ -12,170 +12,257 @@ _WORKFLOWS_DIR="$(cd "$_ORCH_DIR/.." && pwd)"
 _PROJECT_ROOT="$(cd "$_WORKFLOWS_DIR/.." && pwd)"
 _ORIG_DIR="$(pwd)"
 _TMP_DIR="/tmp/type-utils-workflows-tests-$$"
+_PARALLEL_DIR="$_TMP_DIR/parallel"
 
-# Global test counters
-_TESTS_TOTAL=0
-_TESTS_PASSED=0
-_TESTS_FAILED=0
-_TESTS_SKIPPED=0
-_TEST_HELPER_LOADED=1
+_TH_RED=$(printf '\033[0;31m')
+_TH_GREEN=$(printf '\033[0;32m')
+_TH_YELLOW=$(printf '\033[0;33m')
+_TH_CYAN=$(printf '\033[0;36m')
+_TH_BOLD=$(printf '\033[1m')
+_TH_NC=$(printf '\033[0m')
 
-# Color output
-_TH_RED='\033[0;31m'
-_TH_GREEN='\033[0;32m'
-_TH_YELLOW='\033[0;33m'
-_TH_CYAN='\033[0;36m'
-_TH_BOLD='\033[1m'
-_TH_NC='\033[0m'
+mkdir -p "$_TMP_DIR" "$_PARALLEL_DIR"
 
-# Create temp dir
-mkdir -p "$_TMP_DIR"
-
-# Cleanup on exit
 _cleanup() {
-	rm -rf "$_TMP_DIR"
+    rm -rf "$_TMP_DIR"
 }
-trap _cleanup EXIT INT TERM
+
+# Detect logical core count (POSIX portable)
+_NPROC=$(getconf _NPROCESSORS_ONLN 2>/dev/null || nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+_MAX_PARALLEL=${MAX_PARALLEL:-$_NPROC}
 
 # Discover test files: find all workflows/**/__test__/test-*.sh
-# Excludes test-helper.sh and other non-test files (only test-*.sh with pattern)
-# We use a portable approach: walk subdirectories of workflows/
-# Results are written to a temp file to avoid pipe-subshell counter issues
 _discover_test_files() {
-	_list_file="$1"
-	: > "$_list_file"
-	for _subdir in "$_WORKFLOWS_DIR"/*; do
-		[ -d "$_subdir" ] || continue
-		_tdir="$_subdir/__test__"
-		[ -d "$_tdir" ] || continue
-		for _tfile in "$_tdir"/test-*.sh; do
-			[ -f "$_tfile" ] || continue
-			# Skip test-helper.sh (it's a framework, not a test)
-			_tbase=$(basename "$_tfile")
-			case "$_tbase" in
-				test-helper.sh) continue ;;
-			esac
-			# Compute relative path from workflows/
-			_rel="${_tfile#$_WORKFLOWS_DIR/}"
-			echo "$_rel" >> "$_list_file"
-		done
-	done
+    _list_file="$1"
+    : > "$_list_file"
+    for _subdir in "$_WORKFLOWS_DIR"/*; do
+        [ -d "$_subdir" ] || continue
+        _tdir="$_subdir/__test__"
+        [ -d "$_tdir" ] || continue
+        for _tfile in "$_tdir"/test-*.sh; do
+            [ -f "$_tfile" ] || continue
+            _tbase=$(basename "$_tfile")
+            case "$_tbase" in
+            test-helper.sh) continue ;;
+            esac
+            _rel="${_tfile#$_WORKFLOWS_DIR/}"
+            echo "$_rel" >> "$_list_file"
+        done
+    done
 }
 
 _TEST_LIST_FILE="$_TMP_DIR/test-files.txt"
 
 if [ $# -eq 0 ]; then
-	_discover_test_files "$_TEST_LIST_FILE"
+    _discover_test_files "$_TEST_LIST_FILE"
 else
-	: > "$_TEST_LIST_FILE"
-	for _f in "$@"; do
-		# Accept subpaths like release/__test__/test-args.sh or test-args.sh
-		case "$_f" in
-			*__test__/*)
-				_rel="$_f"
-				;;
-			*)
-				_rel=""
-				for _subdir in "$_WORKFLOWS_DIR"/*; do
-					[ -d "$_subdir" ] || continue
-					_tdir="$_subdir/__test__"
-					[ -d "$_tdir" ] || continue
-					[ -f "$_tdir/$_f" ] && _rel="$(basename "$_subdir")/__test__/$_f" && break
-				done
-				;;
-		esac
-		if [ -z "$_rel" ]; then
-			printf "${_TH_RED}ERROR: test file not found: %s${_TH_NC}\n" "$_f" >&2
-			continue
-		fi
-		echo "$_rel" >> "$_TEST_LIST_FILE"
-	done
+    : > "$_TEST_LIST_FILE"
+    for _f in "$@"; do
+        case "$_f" in
+        *__test__/*)
+            _rel="$_f"
+            ;;
+        *)
+            _rel=""
+            for _subdir in "$_WORKFLOWS_DIR"/*; do
+                [ -d "$_subdir" ] || continue
+                _tdir="$_subdir/__test__"
+                [ -d "$_tdir" ] || continue
+                [ -f "$_tdir/$_f" ] && _rel="$(basename "$_subdir")/__test__/$_f" && break
+            done
+            ;;
+        esac
+        if [ -z "$_rel" ]; then
+            printf "${_TH_RED}ERROR: test file not found: %s${_TH_NC}\n" "$_f" >&2
+            continue
+        fi
+        echo "$_rel" >> "$_TEST_LIST_FILE"
+    done
 fi
 
-# Verify we found test files
 if [ ! -s "$_TEST_LIST_FILE" ]; then
-	printf "${_TH_RED}ERROR: No test files found${_TH_NC}\n" >&2
-	exit 1
+    printf "${_TH_RED}ERROR: No test files found${_TH_NC}\n" >&2
+    exit 1
 fi
 
 printf "${_TH_BOLD}${_TH_CYAN}=== workflows Test Suite ===${_TH_NC}\n"
 printf "Shell: %s\n" "$(sh -c 'echo $0')"
-printf "Temp dir: %s\n" "$_TMP_DIR"
+printf "Parallel: up to %d workers (%d cores)\n" "$_MAX_PARALLEL" "$_NPROC"
 printf "Project root: %s\n\n" "$_PROJECT_ROOT"
 
 # Verify POSIX sh compatibility of all scripts in workflows subdirs
 for _subdir in "$_WORKFLOWS_DIR"/*; do
-	[ -d "$_subdir" ] || continue
-	for _script in "$_subdir"/*.sh; do
-		[ -f "$_script" ] || continue
-		_shebang=$(head -1 "$_script")
-		case "$_shebang" in
-			*"/bin/sh"*)
-				printf "${_TH_GREEN}Shebang: %s → %s (POSIX sh)${_TH_NC}\n" "$(basename "$_subdir")/$(basename "$_script")" "$_shebang"
-				;;
-			*"/bin/bash"*|*"bash"*)
-				printf "${_TH_RED}ERROR: %s uses bash shebang, not POSIX sh${_TH_NC}\n" "$(basename "$_subdir")/$(basename "$_script")"
-				exit 1
-				;;
-			*)
-				printf "${_TH_YELLOW}WARNING: unexpected shebang in %s: %s${_TH_NC}\n" "$(basename "$_subdir")/$(basename "$_script")" "$_shebang"
-				;;
-		esac
-	done
+    [ -d "$_subdir" ] || continue
+    for _script in "$_subdir"/*.sh; do
+        [ -f "$_script" ] || continue
+        _shebang=$(head -1 "$_script")
+        case "$_shebang" in
+        *"/bin/sh"*)
+            printf "${_TH_GREEN}Shebang: %s → %s (POSIX sh)${_TH_NC}\n" "$(basename "$_subdir")/$(basename "$_script")" "$_shebang"
+            ;;
+        *"/bin/bash"*|*"bash"*)
+            printf "${_TH_RED}ERROR: %s uses bash shebang, not POSIX sh${_TH_NC}\n" "$(basename "$_subdir")/$(basename "$_script")"
+            exit 1
+            ;;
+        *)
+            printf "${_TH_YELLOW}WARNING: unexpected shebang in %s: %s${_TH_NC}\n" "$(basename "$_subdir")/$(basename "$_script")" "$_shebang"
+            ;;
+        esac
+    done
 done
 
 echo ""
 
-# Export paths for test helper
-export _PROJECT_ROOT
-export _ORIG_DIR
-export _TMP_DIR
+# --- Parallel runner ---
+# Each test file runs in a completely separate `sh -c` process so that:
+#   1. Background jobs don't inherit the parent's EXIT trap (no premature cleanup)
+#   2. Each test has fully isolated variables and temp dirs
+# Concurrency is bounded by $_MAX_PARALLEL (default: logical CPU cores).
+# Results: $_PARALLEL_DIR/<idx>.result  (counters: passed failed skipped total)
+# Output:  $_PARALLEL_DIR/<idx>.output  (test display, buffered until completion)
 
-# Run each test file — iterate via file to avoid pipe-subshell counter issues
+# Build the list of test rel-paths into an indexed file
 _file_count=0
 while IFS= read -r _tf_rel; do
-	[ -z "$_tf_rel" ] && continue
-	_file_count=$((_file_count + 1))
-
-	_test_path="$_WORKFLOWS_DIR/$_tf_rel"
-	if [ ! -f "$_test_path" ]; then
-		printf "${_TH_RED}ERROR: test file not found: %s${_TH_NC}\n" "$_test_path"
-		_TESTS_FAILED=$((_TESTS_FAILED + 1))
-		continue
-	fi
-
-	# Derive the __test__ dir for this test file (where test-helper.sh lives)
-	_test_dir=$(dirname "$_test_path")
-
-	# Export variables needed by test-helper.sh and test files
-	export _REAL_RELEASE_SH="$_PROJECT_ROOT/workflows/release/release.sh"
-	export _REAL_PROMPT_TEMPLATE="$_PROJECT_ROOT/workflows/release/release-readme-prompt.md"
-	export _TEST_DIR="$_test_dir"
-
-	printf "${_TH_BOLD}[%d] Running %s${_TH_NC}\n" "$_file_count" "$_tf_rel"
-
-	# Save counters before sourcing
-	_saved_pass=$_TESTS_PASSED
-	_saved_fail=$_TESTS_FAILED
-	_saved_skip=$_TESTS_SKIPPED
-	_saved_total=$_TESTS_TOTAL
-
-	# Source the test file (it sources test-helper.sh itself)
-	. "$_test_path"
-
-	_file_passed=$((_TESTS_PASSED - _saved_pass))
-	_file_failed=$((_TESTS_FAILED - _saved_fail))
-	_file_skipped=$((_TESTS_SKIPPED - _saved_skip))
-
-	if [ $_file_failed -gt 0 ]; then
-		printf " ${_TH_RED}FAIL: %d passed, %d failed, %d skipped${_TH_NC}\n" \
-			$_file_passed $_file_failed $_file_skipped
-	else
-		printf " ${_TH_GREEN}OK: %d passed, %d skipped${_TH_NC}\n" \
-			$_file_passed $_file_skipped
-	fi
-	echo ""
+    [ -z "$_tf_rel" ] && continue
+    _file_count=$((_file_count + 1))
+    printf '%s\n' "$_tf_rel" >> "$_TMP_DIR/idx-to-rel.txt"
 done < "$_TEST_LIST_FILE"
+
+printf "${_TH_BOLD}Running %d test suites with up to %d parallel workers${_TH_NC}\n\n" "$_file_count" "$_MAX_PARALLEL"
+
+# Build the inline runner script (avoids function+& trap inheritance issues)
+# This runs in a fresh `sh -c` process, so it never inherits the parent's EXIT trap.
+_RUNNER_SCRIPT='
+set -u
+_idx="$1"
+_rel="$2"
+_project_root="$3"
+_orig_dir="$4"
+_tmp_base="$5"
+_parallel_dir="$6"
+_path="${_project_root}/workflows/${_rel}"
+_tmpdir="${_tmp_base}/test-${_idx}"
+_result="${_parallel_dir}/${_idx}.result"
+_output="${_parallel_dir}/${_idx}.output"
+
+mkdir -p "$_tmpdir"
+_tdir=$(dirname "$_path")
+
+# Inner subshell: run the test with its own counters and temp dir.
+# Trap EXIT to always write result counters, even on early exit (die/abort).
+(
+    _TESTS_TOTAL=0
+    _TESTS_PASSED=0
+    _TESTS_FAILED=0
+    _TESTS_SKIPPED=0
+    _TEST_HELPER_LOADED=1
+    _TMP_DIR="$_tmpdir"
+    export _PROJECT_ROOT="$_project_root"
+    export _ORIG_DIR="$_orig_dir"
+    export _TMP_DIR
+    export _REAL_RELEASE_SH="$_project_root/workflows/release/release.sh"
+    export _REAL_PROMPT_TEMPLATE="$_project_root/workflows/release/release-readme-prompt.md"
+    export _TEST_DIR="$_tdir"
+
+    _inner_exit() {
+        printf "%d %d %d %d" $_TESTS_PASSED $_TESTS_FAILED $_TESTS_SKIPPED $_TESTS_TOTAL >&3
+    }
+    trap _inner_exit EXIT
+
+    . "$_path"
+) 3>"$_result" 2>"$_output"
+
+# If result file is empty (subshell crashed before trap), write defaults
+if [ ! -s "$_result" ]; then
+    printf "0 1 0 1" > "$_result"
+fi
+'
+
+# Set cleanup trap AFTER building the runner script, but only for the main process
+trap _cleanup EXIT INT TERM
+
+# Launch test suites with bounded concurrency using a slot counter
+_running=0
+_i=1
+while [ "$_i" -le "$_file_count" ]; do
+    _tf_rel=$(sed -n "${_i}p" "$_TMP_DIR/idx-to-rel.txt")
+    _test_path="$_WORKFLOWS_DIR/$_tf_rel"
+
+    if [ ! -f "$_test_path" ]; then
+        printf "${_TH_RED}ERROR: test file not found: %s${_TH_NC}\n" "$_test_path"
+        printf '0 1 0 1' > "$_PARALLEL_DIR/$_i.result"
+        : > "$_PARALLEL_DIR/$_i.output"
+        _i=$((_i + 1))
+        continue
+    fi
+
+    printf "${_TH_BOLD}[%d/%d] Running %s${_TH_NC}\n" "$_i" "$_file_count" "$_tf_rel"
+
+    # Use `sh -c` so the background process is fully separate — no trap inheritance
+    sh -c "$_RUNNER_SCRIPT" _run_test "$_i" "$_tf_rel" "$_PROJECT_ROOT" "$_ORIG_DIR" "$_TMP_DIR" "$_PARALLEL_DIR" &
+    eval "_PID_$_i=$!"
+    _running=$((_running + 1))
+
+    # If we've hit the parallel limit, wait for the oldest launched job
+    if [ "$_running" -ge "$_MAX_PARALLEL" ]; then
+        _wait_idx=$((_i - _running + 1))
+        eval "_wait_pid=\$_PID_$_wait_idx" 2>/dev/null || true
+        if [ -n "$_wait_pid" ]; then
+            wait "$_wait_pid" 2>/dev/null || true
+        fi
+        _running=$((_running - 1))
+    fi
+
+    _i=$((_i + 1))
+done
+
+# Wait for remaining background jobs
+_i=1
+while [ "$_i" -le "$_file_count" ]; do
+    eval "_pid=\$_PID_$_i" 2>/dev/null || true
+    [ -n "$_pid" ] && wait "$_pid" 2>/dev/null || true
+    _i=$((_i + 1))
+done
+
+# Aggregate results and display buffered output
+_TESTS_TOTAL=0
+_TESTS_PASSED=0
+_TESTS_FAILED=0
+_TESTS_SKIPPED=0
+
+_i=1
+while [ "$_i" -le "$_file_count" ]; do
+    _result_file="$_PARALLEL_DIR/$_i.result"
+    _output_file="$_PARALLEL_DIR/$_i.output"
+    _tf_rel=$(sed -n "${_i}p" "$_TMP_DIR/idx-to-rel.txt")
+
+    # Read counters from result file
+    _res=$(cat "$_result_file" 2>/dev/null || printf '0 1 0 1')
+    _p=$(printf '%s' "$_res" | cut -d' ' -f1)
+    _f=$(printf '%s' "$_res" | cut -d' ' -f2)
+    _s=$(printf '%s' "$_res" | cut -d' ' -f3)
+    _t=$(printf '%s' "$_res" | cut -d' ' -f4)
+
+    # Show test output (buffered from parallel run)
+    if [ -s "$_output_file" ]; then
+        cat "$_output_file"
+    fi
+
+    if [ "$_f" -gt 0 ]; then
+        printf " ${_TH_RED}FAIL: %d passed, %d failed, %d skipped${_TH_NC}\n" "$_p" "$_f" "$_s"
+    else
+        printf " ${_TH_GREEN}OK: %d passed, %d skipped${_TH_NC}\n" "$_p" "$_s"
+    fi
+    echo ""
+
+    _TESTS_PASSED=$((_TESTS_PASSED + _p))
+    _TESTS_FAILED=$((_TESTS_FAILED + _f))
+    _TESTS_SKIPPED=$((_TESTS_SKIPPED + _s))
+    _TESTS_TOTAL=$((_TESTS_TOTAL + _t))
+
+    _i=$((_i + 1))
+done
 
 # Print summary
 echo ""
@@ -186,9 +273,9 @@ printf " ${_TH_RED}Failed: %d${_TH_NC}\n" $_TESTS_FAILED
 printf " ${_TH_YELLOW}Skipped: %d${_TH_NC}\n" $_TESTS_SKIPPED
 echo ""
 if [ $_TESTS_FAILED -gt 0 ]; then
-	printf "${_TH_RED}${_TH_BOLD}FAIL${_TH_NC}\n"
-	exit 1
+    printf "${_TH_RED}${_TH_BOLD}FAIL${_TH_NC}\n"
+    exit 1
 else
-	printf "${_TH_GREEN}${_TH_BOLD}PASS${_TH_NC}\n"
-	exit 0
+    printf "${_TH_GREEN}${_TH_BOLD}PASS${_TH_NC}\n"
+    exit 0
 fi

--- a/workflows/__test__/run-tests.sh
+++ b/workflows/__test__/run-tests.sh
@@ -13,17 +13,56 @@ _PROJECT_ROOT="$(cd "$_WORKFLOWS_DIR/.." && pwd)"
 _ORIG_DIR="$(pwd)"
 _TMP_DIR="/tmp/type-utils-workflows-tests-$$"
 _PARALLEL_DIR="$_TMP_DIR/parallel"
+_FIFO_DIR="$_TMP_DIR/fifos"
 
 _TH_RED=$(printf '\033[0;31m')
 _TH_GREEN=$(printf '\033[0;32m')
 _TH_YELLOW=$(printf '\033[0;33m')
 _TH_CYAN=$(printf '\033[0;36m')
 _TH_BOLD=$(printf '\033[1m')
+_TH_DIM=$(printf '\033[2m')
 _TH_NC=$(printf '\033[0m')
 
-mkdir -p "$_TMP_DIR" "$_PARALLEL_DIR"
+if [ "${NO_COLOR:-}" ]; then
+    _TH_RED=''
+    _TH_GREEN=''
+    _TH_YELLOW=''
+    _TH_CYAN=''
+    _TH_BOLD=''
+    _TH_DIM=''
+    _TH_NC=''
+fi
+
+# TTY-only ANSI escapes
+if [ -t 1 ]; then
+    _IS_TTY=1
+    _TH_SAVE=$(printf '\033[s')
+    _TH_RESTORE=$(printf '\033[u')
+    _TH_CLEAR_EOL=$(printf '\033[K')
+    _TH_CLEAR_SCREEN=$(printf '\033[2J')
+    _TH_HOME=$(printf '\033[H')
+else
+    _IS_TTY=0
+    _TH_SAVE=''
+    _TH_RESTORE=''
+    _TH_CLEAR_EOL=''
+    _TH_CLEAR_SCREEN=''
+    _TH_HOME=''
+fi
+
+mkdir -p "$_TMP_DIR" "$_PARALLEL_DIR" "$_FIFO_DIR"
 
 _cleanup() {
+    _ci=1
+    while [ "$_ci" -le "${_file_count:-0}" ]; do
+        rm -f "$_FIFO_DIR/$_ci.pipe" 2>/dev/null || true
+        eval "_cpid=\$_PID_$_ci" 2>/dev/null || true
+        [ -n "$_cpid" ] && kill "$_cpid" 2>/dev/null || true
+        eval "_rpid=\$_READER_PID_$_ci" 2>/dev/null || true
+        [ -n "$_rpid" ] && kill "$_rpid" 2>/dev/null || true
+        _ci=$((_ci + 1))
+    done
+    [ "$_IS_TTY" -eq 1 ] && printf '%s' "$_TH_RESTORE" 2>/dev/null || true
     rm -rf "$_TMP_DIR"
 }
 
@@ -85,10 +124,11 @@ if [ ! -s "$_TEST_LIST_FILE" ]; then
     exit 1
 fi
 
+# Print header
 printf "${_TH_BOLD}${_TH_CYAN}=== workflows Test Suite ===${_TH_NC}\n"
 printf "Shell: %s\n" "$(sh -c 'echo $0')"
 printf "Parallel: up to %d workers (%d cores)\n" "$_MAX_PARALLEL" "$_NPROC"
-printf "Project root: %s\n\n" "$_PROJECT_ROOT"
+printf "Project root: %s\n" "$_PROJECT_ROOT"
 
 # Verify POSIX sh compatibility of all scripts in workflows subdirs
 for _subdir in "$_WORKFLOWS_DIR"/*; do
@@ -111,16 +151,6 @@ for _subdir in "$_WORKFLOWS_DIR"/*; do
     done
 done
 
-echo ""
-
-# --- Parallel runner ---
-# Each test file runs in a completely separate `sh -c` process so that:
-#   1. Background jobs don't inherit the parent's EXIT trap (no premature cleanup)
-#   2. Each test has fully isolated variables and temp dirs
-# Concurrency is bounded by $_MAX_PARALLEL (default: logical CPU cores).
-# Results: $_PARALLEL_DIR/<idx>.result  (counters: passed failed skipped total)
-# Output:  $_PARALLEL_DIR/<idx>.output  (test display, buffered until completion)
-
 # Build the list of test rel-paths into an indexed file
 _file_count=0
 while IFS= read -r _tf_rel; do
@@ -129,11 +159,282 @@ while IFS= read -r _tf_rel; do
     printf '%s\n' "$_tf_rel" >> "$_TMP_DIR/idx-to-rel.txt"
 done < "$_TEST_LIST_FILE"
 
-printf "${_TH_BOLD}Running %d test suites with up to %d parallel workers${_TH_NC}\n\n" "$_file_count" "$_MAX_PARALLEL"
+# Derive a short label from a test rel-path
+# e.g. "release/__test__/test-args.sh" → "test-args"
+_short_label() {
+    _sl_in="$1"
+    _sl_base=$(basename "$_sl_in")
+    printf '%s' "${_sl_base%.sh}"
+}
 
-# Build the inline runner script (avoids function+& trap inheritance issues)
+# --- Test runner script (shared by both TTY and non-TTY modes) ---
 # This runs in a fresh `sh -c` process, so it never inherits the parent's EXIT trap.
+# Result counters go to fd 3.
+# In TTY mode, stderr goes to fd 4 (the FIFO for live streaming).
+# In non-TTY mode, stderr goes to a per-suite log file.
 _RUNNER_SCRIPT='
+set -u
+_idx="$1"
+_rel="$2"
+_project_root="$3"
+_orig_dir="$4"
+_tmp_base="$5"
+_parallel_dir="$6"
+_fifo_dir="$7"
+_is_tty="$8"
+_path="${_project_root}/workflows/${_rel}"
+_tmpdir="${_tmp_base}/test-${_idx}"
+_result="${_parallel_dir}/${_idx}.result"
+_fifo="${_fifo_dir}/${_idx}.pipe"
+_log="${_parallel_dir}/${_idx}.log"
+
+mkdir -p "$_tmpdir"
+_tdir=$(dirname "$_path")
+
+(
+_TESTS_TOTAL=0
+_TESTS_PASSED=0
+_TESTS_FAILED=0
+_TESTS_SKIPPED=0
+_TEST_HELPER_LOADED=1
+_TMP_DIR="$_tmpdir"
+export _PROJECT_ROOT="$_project_root"
+export _ORIG_DIR="$_orig_dir"
+export _TMP_DIR
+export _REAL_RELEASE_SH="$_project_root/workflows/release/release.sh"
+export _REAL_PROMPT_TEMPLATE="$_project_root/workflows/release/release-readme-prompt.md"
+export _TEST_DIR="$_tdir"
+export _ORCHESTRATOR=1
+
+_inner_exit() {
+    printf "%d %d %d %d" $_TESTS_PASSED $_TESTS_FAILED $_TESTS_SKIPPED $_TESTS_TOTAL >&3
+}
+trap _inner_exit EXIT
+
+. "$_path"
+) 3>"$_result" 2>&4
+'
+
+# Set cleanup trap
+trap _cleanup EXIT INT TERM
+
+# --- TTY mode: live grouped display with ANSI cursor control ---
+# --- Non-TTY mode: plain streaming output ---
+
+# Number of rolling output lines to show per suite (TTY mode only)
+_ROLL_LINES=${ROLL_LINES:-3}
+
+if [ "$_IS_TTY" -eq 1 ]; then
+    # ============================================================
+    # TTY MODE — cursor-control live display
+    # ============================================================
+
+    _STATUS_BLOCK_START=2
+
+    # Create FIFO pipes for live streaming
+    _i=1
+    while [ "$_i" -le "$_file_count" ]; do
+        mkfifo "$_FIFO_DIR/$_i.pipe"
+        _i=$((_i + 1))
+    done
+
+    # Initialize the display: clear screen, draw header and status line placeholders
+    printf '%s' "$_TH_CLEAR_SCREEN$_TH_HOME"
+    printf "${_TH_BOLD}${_TH_CYAN}=== workflows Test Suite ===${_TH_NC} %d suites, up to %d parallel workers (%d cores)\n" "$_file_count" "$_MAX_PARALLEL" "$_NPROC"
+    printf "\n"
+
+    # Print placeholder status lines for each suite
+    _i=1
+    while [ "$_i" -le "$_file_count" ]; do
+        _tf_rel=$(sed -n "${_i}p" "$_TMP_DIR/idx-to-rel.txt")
+        _label=$(_short_label "$_tf_rel")
+        printf " ${_TH_DIM}[%s]${_TH_NC} ${_TH_YELLOW}⏳ waiting${_TH_NC}${_TH_CLEAR_EOL}\n" "$_label"
+        _i=$((_i + 1))
+    done
+
+    # Print blank separator line + output area placeholder
+    printf "\n"
+    _i=1
+    while [ "$_i" -le "$_file_count" ]; do
+        _j=0
+        while [ "$_j" -lt "$_ROLL_LINES" ]; do
+            printf "${_TH_CLEAR_EOL}\n"
+            _j=$((_j + 1))
+        done
+        _i=$((_i + 1))
+    done
+
+    # Save cursor position (below the entire display block)
+    printf '%s' "$_TH_SAVE"
+
+    # Per-suite rolling output buffers
+    _i=1
+    while [ "$_i" -le "$_file_count" ]; do
+        : > "$_PARALLEL_DIR/$_i.roll"
+        _i=$((_i + 1))
+    done
+
+    # Start FIFO reader processes
+    _i=1
+    while [ "$_i" -le "$_file_count" ]; do
+        _tf_rel=$(sed -n "${_i}p" "$_TMP_DIR/idx-to-rel.txt")
+        _label=$(_short_label "$_tf_rel")
+        _status_line=$((_STATUS_BLOCK_START + _i - 1))
+        _output_start_line=$((_STATUS_BLOCK_START + _file_count + 1 + (_i - 1) * _ROLL_LINES))
+        (
+            _rollf="${_PARALLEL_DIR}/${_i}.roll"
+            _sl="$_status_line"
+            _ol="$_output_start_line"
+            _lbl="$_label"
+            _roll="$_ROLL_LINES"
+
+            while IFS= read -r _line; do
+                printf '%s\n' "$_line" >> "$_rollf"
+                _buf_lines=$(wc -l < "$_rollf" 2>/dev/null || echo 0)
+                if [ "$_buf_lines" -gt "$_roll" ]; then
+                    _tail_tmp="${_rollf}.tmp"
+                    tail -"$_roll" "$_rollf" > "$_tail_tmp"
+                    mv "$_tail_tmp" "$_rollf"
+                fi
+
+                printf '\033[%s;1H' "$_ol"
+                _ln=0
+                while IFS= read -r _rline; do
+                    _ln=$((_ln + 1))
+                    if [ -z "$_rline" ]; then
+                        printf "${_TH_CLEAR_EOL}"
+                    else
+                        printf " ${_TH_DIM}[%s]${_TH_NC} %s${_TH_CLEAR_EOL}" "$_lbl" "$_rline"
+                    fi
+                    if [ "$_ln" -lt "$_roll" ]; then
+                        printf '\n'
+                    fi
+                done < "$_rollf"
+
+                _remaining=$((_roll - _ln))
+                _cl=0
+                while [ "$_cl" -lt "$_remaining" ]; do
+                    printf '\n'
+                    printf '%s' "$_TH_CLEAR_EOL"
+                    _cl=$((_cl + 1))
+                done
+
+                printf '%s' "$_TH_RESTORE"
+            done < "$_FIFO_DIR/$_i.pipe"
+        ) &
+        eval "_READER_PID_$_i=$!"
+        _i=$((_i + 1))
+    done
+
+    # Update a suite's status line in-place (TTY only)
+    _update_status() {
+        _us_idx="$1"
+        _us_label="$2"
+        _us_text="$3"
+        _us_line=$((_STATUS_BLOCK_START + _us_idx - 1))
+        printf '\033[%s;1H' "$_us_line"
+        printf " ${_TH_DIM}[%s]${_TH_NC} %s${_TH_CLEAR_EOL}" "$_us_label" "$_us_text"
+        printf '%s' "$_TH_RESTORE"
+    }
+
+    # Launch test suites with bounded concurrency
+    _running=0
+    _i=1
+    while [ "$_i" -le "$_file_count" ]; do
+        _tf_rel=$(sed -n "${_i}p" "$_TMP_DIR/idx-to-rel.txt")
+        _test_path="$_WORKFLOWS_DIR/$_tf_rel"
+        _label=$(_short_label "$_tf_rel")
+
+        if [ ! -f "$_test_path" ]; then
+            _update_status "$_i" "$_label" "${_TH_RED}✗ not found${_TH_NC}"
+            printf '0 1 0 1' > "$_PARALLEL_DIR/$_i.result"
+            _i=$((_i + 1))
+            continue
+        fi
+
+        _update_status "$_i" "$_label" "${_TH_YELLOW}⟳ running${_TH_NC}"
+
+        (
+            sh -c "$_RUNNER_SCRIPT" _run_test "$_i" "$_tf_rel" "$_PROJECT_ROOT" "$_ORIG_DIR" "$_TMP_DIR" "$_PARALLEL_DIR" "$_FIFO_DIR" "$_IS_TTY" \
+            4>"$_FIFO_DIR/$_i.pipe"
+        ) &
+        eval "_PID_$_i=$!"
+        _running=$((_running + 1))
+
+        if [ "$_running" -ge "$_MAX_PARALLEL" ]; then
+            _wait_idx=$((_i - _running + 1))
+            eval "_wait_pid=\$_PID_$_wait_idx" 2>/dev/null || true
+            if [ -n "$_wait_pid" ]; then
+                wait "$_wait_pid" 2>/dev/null || true
+            fi
+            _running=$((_running - 1))
+        fi
+
+        _i=$((_i + 1))
+    done
+
+    # Wait for remaining background test jobs
+    _i=1
+    while [ "$_i" -le "$_file_count" ]; do
+        eval "_pid=\$_PID_$_i" 2>/dev/null || true
+        [ -n "$_pid" ] && wait "$_pid" 2>/dev/null || true
+        _i=$((_i + 1))
+    done
+
+    # Wait for all FIFO reader processes to finish
+    _i=1
+    while [ "$_i" -le "$_file_count" ]; do
+        eval "_rpid=\$_READER_PID_$_i" 2>/dev/null || true
+        [ -n "$_rpid" ] && wait "$_rpid" 2>/dev/null || true
+        _i=$((_i + 1))
+    done
+
+    # Update all status lines with final results
+    _TESTS_TOTAL=0
+    _TESTS_PASSED=0
+    _TESTS_FAILED=0
+    _TESTS_SKIPPED=0
+
+    _i=1
+    while [ "$_i" -le "$_file_count" ]; do
+        _result_file="$_PARALLEL_DIR/$_i.result"
+        _tf_rel=$(sed -n "${_i}p" "$_TMP_DIR/idx-to-rel.txt")
+        _label=$(_short_label "$_tf_rel")
+
+        _res=$(cat "$_result_file" 2>/dev/null || printf '0 1 0 1')
+        _p=$(printf '%s' "$_res" | cut -d' ' -f1)
+        _f=$(printf '%s' "$_res" | cut -d' ' -f2)
+        _s=$(printf '%s' "$_res" | cut -d' ' -f3)
+        _t=$(printf '%s' "$_res" | cut -d' ' -f4)
+
+        if [ "$_f" -gt 0 ]; then
+            _status_text="${_TH_RED}${_TH_BOLD}✗ FAIL${_TH_NC} ${_p} passed, ${_f} failed, ${_s} skipped"
+        else
+            _status_text="${_TH_GREEN}${_TH_BOLD}✓ OK${_TH_NC} ${_p} passed, ${_s} skipped"
+        fi
+        _update_status "$_i" "$_label" "$_status_text"
+
+        _TESTS_PASSED=$((_TESTS_PASSED + _p))
+        _TESTS_FAILED=$((_TESTS_FAILED + _f))
+        _TESTS_SKIPPED=$((_TESTS_SKIPPED + _s))
+        _TESTS_TOTAL=$((_TESTS_TOTAL + _t))
+
+        _i=$((_i + 1))
+    done
+
+    printf '%s' "$_TH_RESTORE"
+
+else
+    # ============================================================
+    # NON-TTY MODE — plain streaming output with [label] prefixes
+    # ============================================================
+
+    # In non-TTY mode, each suite's stderr is captured to a log file.
+    # After all suites finish, we stream the logs with [label] prefixes,
+    # then print the summary.
+
+    # Modify runner script: redirect stderr to log file instead of FIFO
+    _RUNNER_SCRIPT_NTTY='
 set -u
 _idx="$1"
 _rel="$2"
@@ -144,134 +445,133 @@ _parallel_dir="$6"
 _path="${_project_root}/workflows/${_rel}"
 _tmpdir="${_tmp_base}/test-${_idx}"
 _result="${_parallel_dir}/${_idx}.result"
-_output="${_parallel_dir}/${_idx}.output"
+_log="${_parallel_dir}/${_idx}.log"
 
 mkdir -p "$_tmpdir"
 _tdir=$(dirname "$_path")
 
-# Inner subshell: run the test with its own counters and temp dir.
-# Trap EXIT to always write result counters, even on early exit (die/abort).
 (
-    _TESTS_TOTAL=0
-    _TESTS_PASSED=0
-    _TESTS_FAILED=0
-    _TESTS_SKIPPED=0
-    _TEST_HELPER_LOADED=1
-    _TMP_DIR="$_tmpdir"
-    export _PROJECT_ROOT="$_project_root"
-    export _ORIG_DIR="$_orig_dir"
-    export _TMP_DIR
-    export _REAL_RELEASE_SH="$_project_root/workflows/release/release.sh"
-    export _REAL_PROMPT_TEMPLATE="$_project_root/workflows/release/release-readme-prompt.md"
-    export _TEST_DIR="$_tdir"
-
-    _inner_exit() {
-        printf "%d %d %d %d" $_TESTS_PASSED $_TESTS_FAILED $_TESTS_SKIPPED $_TESTS_TOTAL >&3
-    }
-    trap _inner_exit EXIT
-
-    . "$_path"
-) 3>"$_result" 2>"$_output"
-
-# If result file is empty (subshell crashed before trap), write defaults
-if [ ! -s "$_result" ]; then
-    printf "0 1 0 1" > "$_result"
-fi
-'
-
-# Set cleanup trap AFTER building the runner script, but only for the main process
-trap _cleanup EXIT INT TERM
-
-# Launch test suites with bounded concurrency using a slot counter
-_running=0
-_i=1
-while [ "$_i" -le "$_file_count" ]; do
-    _tf_rel=$(sed -n "${_i}p" "$_TMP_DIR/idx-to-rel.txt")
-    _test_path="$_WORKFLOWS_DIR/$_tf_rel"
-
-    if [ ! -f "$_test_path" ]; then
-        printf "${_TH_RED}ERROR: test file not found: %s${_TH_NC}\n" "$_test_path"
-        printf '0 1 0 1' > "$_PARALLEL_DIR/$_i.result"
-        : > "$_PARALLEL_DIR/$_i.output"
-        _i=$((_i + 1))
-        continue
-    fi
-
-    printf "${_TH_BOLD}[%d/%d] Running %s${_TH_NC}\n" "$_i" "$_file_count" "$_tf_rel"
-
-    # Use `sh -c` so the background process is fully separate — no trap inheritance
-    sh -c "$_RUNNER_SCRIPT" _run_test "$_i" "$_tf_rel" "$_PROJECT_ROOT" "$_ORIG_DIR" "$_TMP_DIR" "$_PARALLEL_DIR" &
-    eval "_PID_$_i=$!"
-    _running=$((_running + 1))
-
-    # If we've hit the parallel limit, wait for the oldest launched job
-    if [ "$_running" -ge "$_MAX_PARALLEL" ]; then
-        _wait_idx=$((_i - _running + 1))
-        eval "_wait_pid=\$_PID_$_wait_idx" 2>/dev/null || true
-        if [ -n "$_wait_pid" ]; then
-            wait "$_wait_pid" 2>/dev/null || true
-        fi
-        _running=$((_running - 1))
-    fi
-
-    _i=$((_i + 1))
-done
-
-# Wait for remaining background jobs
-_i=1
-while [ "$_i" -le "$_file_count" ]; do
-    eval "_pid=\$_PID_$_i" 2>/dev/null || true
-    [ -n "$_pid" ] && wait "$_pid" 2>/dev/null || true
-    _i=$((_i + 1))
-done
-
-# Aggregate results and display buffered output
 _TESTS_TOTAL=0
 _TESTS_PASSED=0
 _TESTS_FAILED=0
 _TESTS_SKIPPED=0
+_TEST_HELPER_LOADED=1
+_TMP_DIR="$_tmpdir"
+export _PROJECT_ROOT="$_project_root"
+export _ORIG_DIR="$_orig_dir"
+export _TMP_DIR
+export _REAL_RELEASE_SH="$_project_root/workflows/release/release.sh"
+export _REAL_PROMPT_TEMPLATE="$_project_root/workflows/release/release-readme-prompt.md"
+export _TEST_DIR="$_tdir"
+export _ORCHESTRATOR=1
 
-_i=1
-while [ "$_i" -le "$_file_count" ]; do
-    _result_file="$_PARALLEL_DIR/$_i.result"
-    _output_file="$_PARALLEL_DIR/$_i.output"
-    _tf_rel=$(sed -n "${_i}p" "$_TMP_DIR/idx-to-rel.txt")
+_inner_exit() {
+    printf "%d %d %d %d" $_TESTS_PASSED $_TESTS_FAILED $_TESTS_SKIPPED $_TESTS_TOTAL >&3
+}
+trap _inner_exit EXIT
 
-    # Read counters from result file
-    _res=$(cat "$_result_file" 2>/dev/null || printf '0 1 0 1')
-    _p=$(printf '%s' "$_res" | cut -d' ' -f1)
-    _f=$(printf '%s' "$_res" | cut -d' ' -f2)
-    _s=$(printf '%s' "$_res" | cut -d' ' -f3)
-    _t=$(printf '%s' "$_res" | cut -d' ' -f4)
+. "$_path"
+) 3>"$_result" 2>"$_log"
+'
 
-    # Show test output (buffered from parallel run)
-    if [ -s "$_output_file" ]; then
-        cat "$_output_file"
-    fi
+    # Launch test suites with bounded concurrency
+    _running=0
+    _i=1
+    while [ "$_i" -le "$_file_count" ]; do
+        _tf_rel=$(sed -n "${_i}p" "$_TMP_DIR/idx-to-rel.txt")
+        _test_path="$_WORKFLOWS_DIR/$_tf_rel"
+        _label=$(_short_label "$_tf_rel")
 
-    if [ "$_f" -gt 0 ]; then
-        printf " ${_TH_RED}FAIL: %d passed, %d failed, %d skipped${_TH_NC}\n" "$_p" "$_f" "$_s"
-    else
-        printf " ${_TH_GREEN}OK: %d passed, %d skipped${_TH_NC}\n" "$_p" "$_s"
-    fi
-    echo ""
+        if [ ! -f "$_test_path" ]; then
+            printf '0 1 0 1' > "$_PARALLEL_DIR/$_i.result"
+            : > "$_PARALLEL_DIR/$_i.log"
+            _i=$((_i + 1))
+            continue
+        fi
 
-    _TESTS_PASSED=$((_TESTS_PASSED + _p))
-    _TESTS_FAILED=$((_TESTS_FAILED + _f))
-    _TESTS_SKIPPED=$((_TESTS_SKIPPED + _s))
-    _TESTS_TOTAL=$((_TESTS_TOTAL + _t))
+        printf "${_TH_DIM}[%s]${_TH_NC} ${_TH_YELLOW}⟳ running${_TH_NC}\n" "$_label"
 
-    _i=$((_i + 1))
-done
+        (
+            sh -c "$_RUNNER_SCRIPT_NTTY" _run_test "$_i" "$_tf_rel" "$_PROJECT_ROOT" "$_ORIG_DIR" "$_TMP_DIR" "$_PARALLEL_DIR"
+        ) &
+        eval "_PID_$_i=$!"
+        _running=$((_running + 1))
 
-# Print summary
-echo ""
-printf "${_TH_BOLD}--- Test Summary ---${_TH_NC}\n"
+        if [ "$_running" -ge "$_MAX_PARALLEL" ]; then
+            _wait_idx=$((_i - _running + 1))
+            eval "_wait_pid=\$_PID_$_wait_idx" 2>/dev/null || true
+            if [ -n "$_wait_pid" ]; then
+                wait "$_wait_pid" 2>/dev/null || true
+            fi
+            _running=$((_running - 1))
+        fi
+
+        _i=$((_i + 1))
+    done
+
+    # Wait for remaining background test jobs
+    _i=1
+    while [ "$_i" -le "$_file_count" ]; do
+        eval "_pid=\$_PID_$_i" 2>/dev/null || true
+        [ -n "$_pid" ] && wait "$_pid" 2>/dev/null || true
+        _i=$((_i + 1))
+    done
+
+    # Stream each suite's log with [label] prefix and print per-suite result
+    _TESTS_TOTAL=0
+    _TESTS_PASSED=0
+    _TESTS_FAILED=0
+    _TESTS_SKIPPED=0
+
+    _i=1
+    while [ "$_i" -le "$_file_count" ]; do
+        _tf_rel=$(sed -n "${_i}p" "$_TMP_DIR/idx-to-rel.txt")
+        _label=$(_short_label "$_tf_rel")
+        _log_file="$_PARALLEL_DIR/$_i.log"
+        _result_file="$_PARALLEL_DIR/$_i.result"
+
+        # Stream log output with [label] prefix
+        if [ -s "$_log_file" ]; then
+            while IFS= read -r _logline; do
+                printf " ${_TH_DIM}[%s]${_TH_NC} %s\n" "$_label" "$_logline"
+            done < "$_log_file"
+        fi
+
+        # Read counters from result file
+        _res=$(cat "$_result_file" 2>/dev/null || printf '0 1 0 1')
+        _p=$(printf '%s' "$_res" | cut -d' ' -f1)
+        _f=$(printf '%s' "$_res" | cut -d' ' -f2)
+        _s=$(printf '%s' "$_res" | cut -d' ' -f3)
+        _t=$(printf '%s' "$_res" | cut -d' ' -f4)
+
+        if [ "$_f" -gt 0 ]; then
+            printf " ${_TH_DIM}[%s]${_TH_NC} ${_TH_RED}${_TH_BOLD}✗ FAIL${_TH_NC} ${_p} passed, ${_f} failed, ${_s} skipped\n" "$_label"
+        else
+            printf " ${_TH_DIM}[%s]${_TH_NC} ${_TH_GREEN}${_TH_BOLD}✓ OK${_TH_NC} ${_p} passed, ${_s} skipped\n" "$_label"
+        fi
+
+        _TESTS_PASSED=$((_TESTS_PASSED + _p))
+        _TESTS_FAILED=$((_TESTS_FAILED + _f))
+        _TESTS_SKIPPED=$((_TESTS_SKIPPED + _s))
+        _TESTS_TOTAL=$((_TESTS_TOTAL + _t))
+
+        _i=$((_i + 1))
+    done
+
+fi
+
+# ============================================================
+# Final summary — always printed, both TTY and non-TTY modes
+# ============================================================
+
+printf "\n"
+printf '%s' "${_TH_BOLD}--- Test Summary ---${_TH_NC}"
+printf '\n'
 printf " Total: %d\n" $_TESTS_TOTAL
 printf " ${_TH_GREEN}Passed: %d${_TH_NC}\n" $_TESTS_PASSED
 printf " ${_TH_RED}Failed: %d${_TH_NC}\n" $_TESTS_FAILED
 printf " ${_TH_YELLOW}Skipped: %d${_TH_NC}\n" $_TESTS_SKIPPED
-echo ""
+printf "\n"
 if [ $_TESTS_FAILED -gt 0 ]; then
     printf "${_TH_RED}${_TH_BOLD}FAIL${_TH_NC}\n"
     exit 1

--- a/workflows/release/__test__/test-env.sh
+++ b/workflows/release/__test__/test-env.sh
@@ -8,87 +8,86 @@ _TEST_DIR="${_TEST_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 describe "Environment: .env loading"
 
 it "reads RELEASE_HARNESS from .env"
-    _FAKE_REPO_DIR="$_TMP_DIR/env-harness"
-    create_fake_repo "$_FAKE_REPO_DIR"
-    run_release_dry 0.9.0 --auto
-    assert_contains "$_RUN_OUTPUT" "Harness: echo"
-    test_pass
-    cleanup_fake_repo "$_FAKE_REPO_DIR"
+_FAKE_REPO_DIR="$_TMP_DIR/env-harness"
+create_fake_repo "$_FAKE_REPO_DIR"
+run_release_dry 0.9.0 --auto
+assert_contains "$_RUN_OUTPUT" "Harness: opencode (adapter: opencode)"
+test_pass
+cleanup_fake_repo "$_FAKE_REPO_DIR"
 
 it "reads RELEASE_HARNESS_MODEL from .env"
-    _FAKE_REPO_DIR="$_TMP_DIR/env-model"
-    create_fake_repo "$_FAKE_REPO_DIR"
-    run_release_dry 0.9.0 --auto
-    assert_contains "$_RUN_OUTPUT" "Model: test-model"
-    test_pass
-    cleanup_fake_repo "$_FAKE_REPO_DIR"
+_FAKE_REPO_DIR="$_TMP_DIR/env-model"
+create_fake_repo "$_FAKE_REPO_DIR"
+run_release_dry 0.9.0 --auto
+assert_contains "$_RUN_OUTPUT" "Model: test-model"
+test_pass
+cleanup_fake_repo "$_FAKE_REPO_DIR"
 
 it "uses default harness when .env missing"
-    _FAKE_REPO_DIR="$_TMP_DIR/env-default"
-    create_fake_repo "$_FAKE_REPO_DIR"
-    cd "$_FAKE_REPO_DIR"
-    rm -f .env
-    cd "$_ORIG_DIR"
-    # Without .env, default is "opencode" — but opencode likely isn't in PATH
-    # so --auto will die. Test with --harness override instead
-    run_release_dry 0.9.0 --auto --harness echo
-    assert_contains "$_RUN_OUTPUT" "Harness: echo"
-    test_pass
-    cleanup_fake_repo "$_FAKE_REPO_DIR"
+_FAKE_REPO_DIR="$_TMP_DIR/env-default"
+create_fake_repo "$_FAKE_REPO_DIR"
+cd "$_FAKE_REPO_DIR"
+rm -f .env
+cd "$_ORIG_DIR"
+# Without .env, default is "opencode" — the stub binary should be in PATH
+run_release_dry 0.9.0 --auto
+assert_contains "$_RUN_OUTPUT" "Harness: opencode (adapter: opencode)"
+test_pass
+cleanup_fake_repo "$_FAKE_REPO_DIR"
 
 describe "Environment: --harness override"
 
 it "overrides harness from .env"
-    _FAKE_REPO_DIR="$_TMP_DIR/env-override"
-    create_fake_repo "$_FAKE_REPO_DIR"
-    run_release_dry 0.9.0 --auto --harness cat
-    assert_contains "$_RUN_OUTPUT" "Harness: cat"
-    test_pass
-    cleanup_fake_repo "$_FAKE_REPO_DIR"
+_FAKE_REPO_DIR="$_TMP_DIR/env-override"
+create_fake_repo "$_FAKE_REPO_DIR"
+run_release_dry 0.9.0 --auto --harness opencode
+assert_contains "$_RUN_OUTPUT" "Harness: opencode"
+test_pass
+cleanup_fake_repo "$_FAKE_REPO_DIR"
 
 it "dies when harness executable not found in PATH"
-    _FAKE_REPO_DIR="$_TMP_DIR/env-notfound"
-    create_fake_repo "$_FAKE_REPO_DIR"
-    cd "$_FAKE_REPO_DIR"
-    _output=$(sh workflows/release/release.sh 0.9.0 --auto --harness nonexistent-binary-xyz 2>&1) && _rc=0 || _rc=$?
-    cd "$_ORIG_DIR"
-    assert_exit_code 1 "$_rc"
-    assert_contains "$_output" "not found in PATH"
-    test_pass
-    cleanup_fake_repo "$_FAKE_REPO_DIR"
+_FAKE_REPO_DIR="$_TMP_DIR/env-notfound"
+create_fake_repo "$_FAKE_REPO_DIR"
+cd "$_FAKE_REPO_DIR"
+_output=$(PATH="$(pwd)/bin:${PATH}" sh workflows/release/release.sh 0.9.0 --auto --harness nonexistent-binary-xyz 2>&1) && _rc=0 || _rc=$?
+cd "$_ORIG_DIR"
+assert_exit_code 1 "$_rc"
+assert_contains "$_output" "not a supported adapter"
+test_pass
+cleanup_fake_repo "$_FAKE_REPO_DIR"
 
 describe "Environment: .env with comments and blanks"
 
 it "ignores comment lines in .env"
-    _FAKE_REPO_DIR="$_TMP_DIR/env-comments"
-    create_fake_repo "$_FAKE_REPO_DIR"
-    cd "$_FAKE_REPO_DIR"
-    cat > .env <<'ENVEOF'
+_FAKE_REPO_DIR="$_TMP_DIR/env-comments"
+create_fake_repo "$_FAKE_REPO_DIR"
+cd "$_FAKE_REPO_DIR"
+cat > .env <<'ENVEOF'
 # This is a comment
-RELEASE_HARNESS=echo
+RELEASE_HARNESS=opencode
 # Another comment
 RELEASE_HARNESS_MODEL=test-model
 ENVEOF
-    cd "$_ORIG_DIR"
-    run_release_dry 0.9.0 --auto
-    assert_contains "$_RUN_OUTPUT" "Harness: echo"
-    assert_contains "$_RUN_OUTPUT" "Model: test-model"
-    test_pass
-    cleanup_fake_repo "$_FAKE_REPO_DIR"
+cd "$_ORIG_DIR"
+run_release_dry 0.9.0 --auto
+assert_contains "$_RUN_OUTPUT" "Harness: opencode"
+assert_contains "$_RUN_OUTPUT" "Model: test-model"
+test_pass
+cleanup_fake_repo "$_FAKE_REPO_DIR"
 
 it "ignores blank lines in .env"
-    _FAKE_REPO_DIR="$_TMP_DIR/env-blanks"
-    create_fake_repo "$_FAKE_REPO_DIR"
-    cd "$_FAKE_REPO_DIR"
-    cat > .env <<'ENVEOF'
+_FAKE_REPO_DIR="$_TMP_DIR/env-blanks"
+create_fake_repo "$_FAKE_REPO_DIR"
+cd "$_FAKE_REPO_DIR"
+cat > .env <<'ENVEOF'
 
-RELEASE_HARNESS=echo
+RELEASE_HARNESS=opencode
 
 RELEASE_HARNESS_MODEL=test-model
 
 ENVEOF
-    cd "$_ORIG_DIR"
-    run_release_dry 0.9.0 --auto
-    assert_contains "$_RUN_OUTPUT" "Harness: echo"
-    test_pass
-    cleanup_fake_repo "$_FAKE_REPO_DIR"
+cd "$_ORIG_DIR"
+run_release_dry 0.9.0 --auto
+assert_contains "$_RUN_OUTPUT" "Harness: opencode"
+test_pass
+cleanup_fake_repo "$_FAKE_REPO_DIR"

--- a/workflows/release/__test__/test-helper.sh
+++ b/workflows/release/__test__/test-helper.sh
@@ -17,6 +17,11 @@ _CURRENT_IT=""
 _TEST_FILE=""
 _ASSERTIONS_IN_TEST=0
 
+if [ -z "${_ORCHESTRATOR:-}" ]; then
+    _standalone_summary() { print_summary; }
+    trap _standalone_summary EXIT
+fi
+
 # --- Color output ---
 
 _TH_RED=$(printf '\033[0;31m')
@@ -26,294 +31,291 @@ _TH_CYAN=$(printf '\033[0;36m')
 _TH_BOLD=$(printf '\033[1m')
 _TH_NC=$(printf '\033[0m')
 
+if [ "${NO_COLOR:-}" ]; then
+    _TH_RED=''
+    _TH_GREEN=''
+    _TH_YELLOW=''
+    _TH_CYAN=''
+    _TH_BOLD=''
+    _TH_NC=''
+fi
+
 # --- Output helpers ---
+# All output goes to stderr (fd 2).
+# Indentation is embedded in pass/fail/skip so that when the parallel
+# runner prefixes each line with [label], the indent sits AFTER the
+# prefix, not before it.
 
-_th_indent() {
-    if [ -n "$_CURRENT_DESCRIBE" ]; then
-        printf "  "
-    fi
-}
-
-pass() { printf "${_TH_GREEN}✓${_TH_NC} %s\n" "$*" >&2; }
-fail() { printf "${_TH_RED}✗${_TH_NC} %s\n" "$*" >&2; }
-skip() { printf "${_TH_YELLOW}⊘${_TH_NC} %s\n" "$*" >&2; }
+pass() { printf "  ${_TH_GREEN}✓${_TH_NC} %s\n" "$*" >&2; }
+fail() { printf "  ${_TH_RED}✗${_TH_NC} %s\n" "$*" >&2; }
+skip() { printf "  ${_TH_YELLOW}⊘${_TH_NC} %s\n" "$*" >&2; }
 
 # --- Test registration ---
 
 describe() {
 _CURRENT_DESCRIBE="$1"
-printf "\n${_TH_BOLD}${_TH_CYAN}%s${_TH_NC}\n" "$1" >&2
+printf "${_TH_BOLD}${_TH_CYAN}%s${_TH_NC}\n" "$1" >&2
 }
 
 it() {
-    _CURRENT_IT="$1"
-    _ASSERTIONS_IN_TEST=0
+_CURRENT_IT="$1"
+_ASSERTIONS_IN_TEST=0
 }
 
 # --- Assertions ---
 
 assert_equal() {
-    _ASSERTIONS_IN_TEST=$((_ASSERTIONS_IN_TEST + 1))
-    _ae_expected="$1"
-    _ae_actual="$2"
-    _ae_msg="${3:-expected '$_ae_expected' got '$_ae_actual'}"
-    if [ "$_ae_expected" = "$_ae_actual" ]; then
-        : # silent on pass
-    else
-        _th_indent
-        fail "$_CURRENT_IT: $_ae_msg"
-        _TESTS_FAILED=$((_TESTS_FAILED + 1))
-        _TESTS_TOTAL=$((_TESTS_TOTAL + 1))
-        return 1
-    fi
-    return 0
+_ASSERTIONS_IN_TEST=$((_ASSERTIONS_IN_TEST + 1))
+_ae_expected="$1"
+_ae_actual="$2"
+_ae_msg="${3:-expected '$_ae_expected' got '$_ae_actual'}"
+if [ "$_ae_expected" = "$_ae_actual" ]; then
+:
+else
+fail "$_CURRENT_IT: $_ae_msg"
+_TESTS_FAILED=$((_TESTS_FAILED + 1))
+_TESTS_TOTAL=$((_TESTS_TOTAL + 1))
+return 1
+fi
+return 0
 }
 
 assert_not_equal() {
-    _ASSERTIONS_IN_TEST=$((_ASSERTIONS_IN_TEST + 1))
-    _ane_expected="$1"
-    _ane_actual="$2"
-    _ane_msg="${3:-expected '$_ane_expected' to differ from '$_ane_actual'}"
-    if [ "$_ane_expected" != "$_ane_actual" ]; then
-        :
-    else
-        _th_indent
-        fail "$_CURRENT_IT: $_ane_msg"
-        _TESTS_FAILED=$((_TESTS_FAILED + 1))
-        _TESTS_TOTAL=$((_TESTS_TOTAL + 1))
-        return 1
-    fi
-    return 0
+_ASSERTIONS_IN_TEST=$((_ASSERTIONS_IN_TEST + 1))
+_ane_expected="$1"
+_ane_actual="$2"
+_ane_msg="${3:-expected '$_ane_expected' to differ from '$_ane_actual'}"
+if [ "$_ane_expected" != "$_ane_actual" ]; then
+:
+else
+fail "$_CURRENT_IT: $_ane_msg"
+_TESTS_FAILED=$((_TESTS_FAILED + 1))
+_TESTS_TOTAL=$((_TESTS_TOTAL + 1))
+return 1
+fi
+return 0
 }
 
 assert_contains() {
-    _ASSERTIONS_IN_TEST=$((_ASSERTIONS_IN_TEST + 1))
-    _ac_haystack="$1"
-    _ac_needle="$2"
-    _ac_msg="${3:-expected to find '$_ac_needle' in output}"
-    case "$_ac_haystack" in
-        *"$_ac_needle"*)
-            :
-            ;;
-        *)
-            _th_indent
-            fail "$_CURRENT_IT: $_ac_msg"
-            _TESTS_FAILED=$((_TESTS_FAILED + 1))
-            _TESTS_TOTAL=$((_TESTS_TOTAL + 1))
-            return 1
-            ;;
-    esac
-    return 0
+_ASSERTIONS_IN_TEST=$((_ASSERTIONS_IN_TEST + 1))
+_ac_haystack="$1"
+_ac_needle="$2"
+_ac_msg="${3:-expected to find '$_ac_needle' in output}"
+case "$_ac_haystack" in
+*"$_ac_needle"*)
+:
+;;
+*)
+fail "$_CURRENT_IT: $_ac_msg"
+_TESTS_FAILED=$((_TESTS_FAILED + 1))
+_TESTS_TOTAL=$((_TESTS_TOTAL + 1))
+return 1
+;;
+esac
+return 0
 }
 
 assert_not_contains() {
-    _ASSERTIONS_IN_TEST=$((_ASSERTIONS_IN_TEST + 1))
-    _anc_haystack="$1"
-    _anc_needle="$2"
-    _anc_msg="${3:-expected NOT to find '$_anc_needle' in output}"
-    case "$_anc_haystack" in
-        *"$_anc_needle"*)
-            _th_indent
-            fail "$_CURRENT_IT: $_anc_msg"
-            _TESTS_FAILED=$((_TESTS_FAILED + 1))
-            _TESTS_TOTAL=$((_TESTS_TOTAL + 1))
-            return 1
-            ;;
-    esac
-    return 0
+_ASSERTIONS_IN_TEST=$((_ASSERTIONS_IN_TEST + 1))
+_anc_haystack="$1"
+_anc_needle="$2"
+_anc_msg="${3:-expected NOT to find '$_anc_needle' in output}"
+case "$_anc_haystack" in
+*"$_anc_needle"*)
+fail "$_CURRENT_IT: $_anc_msg"
+_TESTS_FAILED=$((_TESTS_FAILED + 1))
+_TESTS_TOTAL=$((_TESTS_TOTAL + 1))
+return 1
+;;
+esac
+return 0
 }
 
 assert_exit_code() {
-    _ASSERTIONS_IN_TEST=$((_ASSERTIONS_IN_TEST + 1))
-    _aec_expected="$1"
-    _aec_actual="$2"
-    _aec_msg="${3:-expected exit code $_aec_expected, got $_aec_actual}"
-    if [ "$_aec_expected" != "$_aec_actual" ]; then
-        _th_indent
-        fail "$_CURRENT_IT: $_aec_msg"
-        _TESTS_FAILED=$((_TESTS_FAILED + 1))
-        _TESTS_TOTAL=$((_TESTS_TOTAL + 1))
-        return 1
-    fi
-    return 0
+_ASSERTIONS_IN_TEST=$((_ASSERTIONS_IN_TEST + 1))
+_aec_expected="$1"
+_aec_actual="$2"
+_aec_msg="${3:-expected exit code $_aec_expected, got $_aec_actual}"
+if [ "$_aec_expected" != "$_aec_actual" ]; then
+fail "$_CURRENT_IT: $_ae_msg"
+_TESTS_FAILED=$((_TESTS_FAILED + 1))
+_TESTS_TOTAL=$((_TESTS_TOTAL + 1))
+return 1
+fi
+return 0
 }
 
 assert_file_exists() {
-    _ASSERTIONS_IN_TEST=$((_ASSERTIONS_IN_TEST + 1))
-    _afe_path="$1"
-    _afe_msg="${2:-expected file '$_afe_path' to exist}"
-    if [ -f "$_afe_path" ]; then
-        :
-    else
-        _th_indent
-        fail "$_CURRENT_IT: $_afe_msg"
-        _TESTS_FAILED=$((_TESTS_FAILED + 1))
-        _TESTS_TOTAL=$((_TESTS_TOTAL + 1))
-        return 1
-    fi
-    return 0
+_ASSERTIONS_IN_TEST=$((_ASSERTIONS_IN_TEST + 1))
+_afe_path="$1"
+_afe_msg="${2:-expected file '$_afe_path' to exist}"
+if [ -f "$_afe_path" ]; then
+:
+else
+fail "$_CURRENT_IT: $_afe_msg"
+_TESTS_FAILED=$((_TESTS_FAILED + 1))
+_TESTS_TOTAL=$((_TESTS_TOTAL + 1))
+return 1
+fi
+return 0
 }
 
 assert_file_not_exists() {
-    _ASSERTIONS_IN_TEST=$((_ASSERTIONS_IN_TEST + 1))
-    _afne_path="$1"
-    _afne_msg="${2:-expected file '$_afne_path' NOT to exist}"
-    if [ ! -f "$_afne_path" ]; then
-        :
-    else
-        _th_indent
-        fail "$_CURRENT_IT: $_afne_msg"
-        _TESTS_FAILED=$((_TESTS_FAILED + 1))
-        _TESTS_TOTAL=$((_TESTS_TOTAL + 1))
-        return 1
-    fi
-    return 0
+_ASSERTIONS_IN_TEST=$((_ASSERTIONS_IN_TEST + 1))
+_afne_path="$1"
+_afne_msg="${2:-expected file '$_afne_path' NOT to exist}"
+if [ ! -f "$_afne_path" ]; then
+:
+else
+fail "$_CURRENT_IT: $_afne_msg"
+_TESTS_FAILED=$((_TESTS_FAILED + 1))
+_TESTS_TOTAL=$((_TESTS_TOTAL + 1))
+return 1
+fi
+return 0
 }
 
 assert_dir_exists() {
-    _ASSERTIONS_IN_TEST=$((_ASSERTIONS_IN_TEST + 1))
-    _ade_path="$1"
-    _ade_msg="${2:-expected directory '$_ade_path' to exist}"
-    if [ -d "$_ade_path" ]; then
-        :
-    else
-        _th_indent
-        fail "$_CURRENT_IT: $_ade_msg"
-        _TESTS_FAILED=$((_TESTS_FAILED + 1))
-        _TESTS_TOTAL=$((_TESTS_TOTAL + 1))
-        return 1
-    fi
-    return 0
+_ASSERTIONS_IN_TEST=$((_ASSERTIONS_IN_TEST + 1))
+_ade_path="$1"
+_ade_msg="${2:-expected directory '$_ade_path' to exist}"
+if [ -d "$_ade_path" ]; then
+:
+else
+fail "$_CURRENT_IT: $_ade_msg"
+_TESTS_FAILED=$((_TESTS_FAILED + 1))
+_TESTS_TOTAL=$((_TESTS_TOTAL + 1))
+return 1
+fi
+return 0
 }
 
 # Mark current it() as passed (call at end of a successful test)
 test_pass() {
-    if [ $_ASSERTIONS_IN_TEST -gt 0 ]; then
-        _th_indent
-        pass "$_CURRENT_IT"
-        _TESTS_PASSED=$((_TESTS_PASSED + 1))
-        _TESTS_TOTAL=$((_TESTS_TOTAL + 1))
-    fi
+if [ $_ASSERTIONS_IN_TEST -gt 0 ]; then
+pass "$_CURRENT_IT"
+_TESTS_PASSED=$((_TESTS_PASSED + 1))
+_TESTS_TOTAL=$((_TESTS_TOTAL + 1))
+fi
 }
 
 # Mark current it() as skipped
 test_skip() {
-    _th_indent
-    skip "$_CURRENT_IT (skipped)"
-    _TESTS_SKIPPED=$((_TESTS_SKIPPED + 1))
-    _TESTS_TOTAL=$((_TESTS_TOTAL + 1))
+skip "$_CURRENT_IT (skipped)"
+_TESTS_SKIPPED=$((_TESTS_SKIPPED + 1))
+_TESTS_TOTAL=$((_TESTS_TOTAL + 1))
 }
 
 # --- Test fixture: create a fake git repo ---
 
 create_fake_repo() {
-    _cfr_dir="$1"
-    rm -rf "$_cfr_dir"
-    mkdir -p "$_cfr_dir"
-    cd "$_cfr_dir"
-    git init -q
-    git config user.email "test@test.com"
-    git config user.name "Test"
+_cfr_dir="$1"
+rm -rf "$_cfr_dir"
+mkdir -p "$_cfr_dir"
+cd "$_cfr_dir"
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
 
-    # Minimal package.json
-    cat > package.json <<'PKGJSON'
+# Minimal package.json
+cat > package.json <<'PKGJSON'
 {
-  "name": "@srhenry/type-utils",
-  "version": "0.8.0"
+"name": "@srhenry/type-utils",
+"version": "0.8.0"
 }
 PKGJSON
 
-	mkdir -p workflows/release
-	# Copy the real release.sh
-	cp "$_REAL_RELEASE_SH" workflows/release/release.sh
-	chmod +x workflows/release/release.sh
+mkdir -p workflows/release
+# Copy the real release.sh
+cp "$_REAL_RELEASE_SH" workflows/release/release.sh
+chmod +x workflows/release/release.sh
 
-    # Copy prompt template
-    cp "$_REAL_PROMPT_TEMPLATE" workflows/release/release-readme-prompt.md 2>/dev/null || true
+# Copy prompt template
+cp "$_REAL_PROMPT_TEMPLATE" workflows/release/release-readme-prompt.md 2>/dev/null || true
 
-    # Create a stub opencode binary for harness adapter tests
-    mkdir -p bin
-    cat > bin/opencode <<'STUBOPENCODE'
+# Create a stub opencode binary for harness adapter tests
+mkdir -p bin
+cat > bin/opencode <<'STUBOPENCODE'
 #!/bin/sh
 # Stub opencode for release.sh tests
 # Simulates successful harness run with JSON output
 case "$1" in
 run)
-    # Find --title value for session ID
-    _stub_title="release-automation-stub"
-    for _stub_arg in "$@"; do
-        case "$_prev_arg" in --title) _stub_title="$_stub_arg" ;; esac
-        _prev_arg="$_stub_arg"
-    done
-    printf '{"type":"step_start","sessionID":"ses_stub123","title":"%s"}\n' "$_stub_title"
-    exit 0
-    ;;
+# Find --title value for session ID
+_stub_title="release-automation-stub"
+for _stub_arg in "$@"; do
+case "$_prev_arg" in --title) _stub_title="$_stub_arg" ;; esac
+_prev_arg="$_stub_arg"
+done
+printf '{"type":"step_start","sessionID":"ses_stub123","title":"%s"}\n' "$_stub_title"
+exit 0
+;;
 session)
-    case "$2" in delete) exit 0 ;; esac
-    ;;
+case "$2" in delete) exit 0 ;; esac
+;;
 esac
 exit 0
 STUBOPENCODE
-    chmod +x bin/opencode
+chmod +x bin/opencode
 
-    # Create fake .env (gitignored, like the real project)
-    cat > .env <<'ENVFILE'
+# Create fake .env (gitignored, like the real project)
+cat > .env <<'ENVFILE'
 RELEASE_HARNESS=opencode
 RELEASE_HARNESS_MODEL=test-model
 RELEASE_HARNESS_ARGS=--test
 ENVFILE
 
-    # .gitignore matching the real project conventions
-    cat > .gitignore <<'GITIGNORE'
+# .gitignore matching the real project conventions
+cat > .gitignore <<'GITIGNORE'
 .env
 .env.*
 !.env.example
 GITIGNORE
 
-    # Initial commit + tag
-    git add -A
-    git commit -q -m "chore: initial commit"
-    git tag -a "v0.7.0" -m "v0.7.0"
+# Initial commit + tag
+git add -A
+git commit -q -m "chore: initial commit"
+git tag -a "v0.7.0" -m "v0.7.0"
 
-    # Some feature commits on master
-    echo "feature1" > feature1.txt
-    git add -A
-    git commit -q -m "feat: add feature1 a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
-    echo "feature2" > feature2.txt
-    git add -A
-    git commit -q -m "fix: fix bug in feature1 b2c3d4e5f6a7b2c3d4e5f6a7b2c3d4e5f6a7b2c3"
-    git tag -a "v0.8.0" -m "v0.8.0"
+# Some feature commits on master
+echo "feature1" > feature1.txt
+git add -A
+git commit -q -m "feat: add feature1 a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+echo "feature2" > feature2.txt
+git add -A
+git commit -q -m "fix: fix bug in feature1 b2c3d4e5f6a7b2c3d4e5f6a7b2c3d4e5f6a7b2c3"
+git tag -a "v0.8.0" -m "v0.8.0"
 
-    # Additional commits after v0.8.0
-    echo "feature3" > feature3.txt
-    git add -A
-    git commit -q -m "feat: add feature3 c3d4e5f6a7b8c3d4e5f6a7b8c3d4e5f6a7b8c3d4"
-    echo "feature4" > feature4.txt
-    git add -A
-    git commit -q -m "docs: update readme d4e5f6a7b8c9d4e5f6a7b8c9d4e5f6a7b8c9d4e5"
+# Additional commits after v0.8.0
+echo "feature3" > feature3.txt
+git add -A
+git commit -q -m "feat: add feature3 c3d4e5f6a7b8c3d4e5f6a7b8c3d4e5f6a7b8c3d4"
+echo "feature4" > feature4.txt
+git add -A
+git commit -q -m "docs: update readme d4e5f6a7b8c9d4e5f6a7b8c9d4e5f6a7b8c9d4e5"
 
-    # Add a fake remote so script doesn't die on "No git remotes"
-    git remote add origin https://github.com/fake/test.git 2>/dev/null || true
+# Add a fake remote so script doesn't die on "No git remotes"
+git remote add origin https://github.com/fake/test.git 2>/dev/null || true
 }
 
 # Create a fake repo with a developer branch
 create_fake_repo_with_developer() {
-    _cfrwd_dir="$1"
-    create_fake_repo "$_cfrwd_dir"
+_cfrwd_dir="$1"
+create_fake_repo "$_cfrwd_dir"
 
-    # Create developer branch from before v0.8.0
-    git checkout -q -b developer HEAD~2
-    echo "dev-feature" > dev-feature.txt
-    git add -A
-    git commit -q -m "feat: dev-only feature e5f6a7b8c9d0e5f6a7b8c9d0e5f6a7b8c9d0e5f6"
-    git checkout -q master
+# Create developer branch from before v0.8.0
+git checkout -q -b developer HEAD~2
+echo "dev-feature" > dev-feature.txt
+git add -A
+git commit -q -m "feat: dev-only feature e5f6a7b8c9d0e5f6a7b8c9d0e5f6a7b8c9d0e5f6"
+git checkout -q master
 }
 
 # Cleanup fake repo
 cleanup_fake_repo() {
-    _cfr_cleanup_dir="$1"
-    cd "$_ORIG_DIR"
-    rm -rf "$_cfr_cleanup_dir"
+_cfr_cleanup_dir="$1"
+cd "$_ORIG_DIR"
+rm -rf "$_cfr_cleanup_dir"
 }
 
 # Run release.sh and capture output + exit code
@@ -342,7 +344,8 @@ _RUN_EXIT_CODE=$_rrd_rc
 
 print_summary() {
 echo "" >&2
-printf "${_TH_BOLD}--- Test Summary ---${_TH_NC}\n" >&2
+printf '%s' "${_TH_BOLD}--- Test Summary ---${_TH_NC}" >&2
+printf '\n' >&2
 printf " Total: %d\n" $_TESTS_TOTAL >&2
 printf " ${_TH_GREEN}Passed: %d${_TH_NC}\n" $_TESTS_PASSED >&2
 printf " ${_TH_RED}Failed: %d${_TH_NC}\n" $_TESTS_FAILED >&2

--- a/workflows/release/__test__/test-helper.sh
+++ b/workflows/release/__test__/test-helper.sh
@@ -19,12 +19,12 @@ _ASSERTIONS_IN_TEST=0
 
 # --- Color output ---
 
-_TH_RED='\033[0;31m'
-_TH_GREEN='\033[0;32m'
-_TH_YELLOW='\033[0;33m'
-_TH_CYAN='\033[0;36m'
-_TH_BOLD='\033[1m'
-_TH_NC='\033[0m'
+_TH_RED=$(printf '\033[0;31m')
+_TH_GREEN=$(printf '\033[0;32m')
+_TH_YELLOW=$(printf '\033[0;33m')
+_TH_CYAN=$(printf '\033[0;36m')
+_TH_BOLD=$(printf '\033[1m')
+_TH_NC=$(printf '\033[0m')
 
 # --- Output helpers ---
 
@@ -34,15 +34,15 @@ _th_indent() {
     fi
 }
 
-pass() { printf "${_TH_GREEN}✓${_TH_NC} %s\n" "$*"; }
+pass() { printf "${_TH_GREEN}✓${_TH_NC} %s\n" "$*" >&2; }
 fail() { printf "${_TH_RED}✗${_TH_NC} %s\n" "$*" >&2; }
-skip() { printf "${_TH_YELLOW}⊘${_TH_NC} %s\n" "$*"; }
+skip() { printf "${_TH_YELLOW}⊘${_TH_NC} %s\n" "$*" >&2; }
 
 # --- Test registration ---
 
 describe() {
-    _CURRENT_DESCRIBE="$1"
-    printf "\n${_TH_BOLD}${_TH_CYAN}%s${_TH_NC}\n" "$1"
+_CURRENT_DESCRIBE="$1"
+printf "\n${_TH_BOLD}${_TH_CYAN}%s${_TH_NC}\n" "$1" >&2
 }
 
 it() {
@@ -228,12 +228,37 @@ PKGJSON
 	cp "$_REAL_RELEASE_SH" workflows/release/release.sh
 	chmod +x workflows/release/release.sh
 
-	# Copy prompt template
-	cp "$_REAL_PROMPT_TEMPLATE" workflows/release/release-readme-prompt.md 2>/dev/null || true
+    # Copy prompt template
+    cp "$_REAL_PROMPT_TEMPLATE" workflows/release/release-readme-prompt.md 2>/dev/null || true
+
+    # Create a stub opencode binary for harness adapter tests
+    mkdir -p bin
+    cat > bin/opencode <<'STUBOPENCODE'
+#!/bin/sh
+# Stub opencode for release.sh tests
+# Simulates successful harness run with JSON output
+case "$1" in
+run)
+    # Find --title value for session ID
+    _stub_title="release-automation-stub"
+    for _stub_arg in "$@"; do
+        case "$_prev_arg" in --title) _stub_title="$_stub_arg" ;; esac
+        _prev_arg="$_stub_arg"
+    done
+    printf '{"type":"step_start","sessionID":"ses_stub123","title":"%s"}\n' "$_stub_title"
+    exit 0
+    ;;
+session)
+    case "$2" in delete) exit 0 ;; esac
+    ;;
+esac
+exit 0
+STUBOPENCODE
+    chmod +x bin/opencode
 
     # Create fake .env (gitignored, like the real project)
     cat > .env <<'ENVFILE'
-RELEASE_HARNESS=echo
+RELEASE_HARNESS=opencode
 RELEASE_HARNESS_MODEL=test-model
 RELEASE_HARNESS_ARGS=--test
 ENVFILE
@@ -293,42 +318,41 @@ cleanup_fake_repo() {
 
 # Run release.sh and capture output + exit code
 run_release() {
-    _rr_output_file="$_TMP_DIR/release_output.txt"
-    _rr_rc=0
-    cd "$_FAKE_REPO_DIR"
-    # Redirect stderr into stdout for capture
-	sh workflows/release/release.sh "$@" > "$_rr_output_file" 2>&1 || _rr_rc=$?
-    cd "$_ORIG_DIR"
-    _RUN_OUTPUT=$(cat "$_rr_output_file")
-    _RUN_EXIT_CODE=$_rr_rc
+_rr_output_file="$_TMP_DIR/release_output.txt"
+_rr_rc=0
+cd "$_FAKE_REPO_DIR"
+PATH="$(pwd)/bin:${PATH}" sh workflows/release/release.sh "$@" > "$_rr_output_file" 2>&1 || _rr_rc=$?
+cd "$_ORIG_DIR"
+_RUN_OUTPUT=$(cat "$_rr_output_file")
+_RUN_EXIT_CODE=$_rr_rc
 }
 
 # Run release.sh with --dry-run (safe, no mutations)
 run_release_dry() {
-    _rrd_output_file="$_TMP_DIR/release_dry_output.txt"
-    _rrd_rc=0
-    cd "$_FAKE_REPO_DIR"
-	sh workflows/release/release.sh --dry-run "$@" > "$_rrd_output_file" 2>&1 || _rrd_rc=$?
-    cd "$_ORIG_DIR"
-    _RUN_OUTPUT=$(cat "$_rrd_output_file")
-    _RUN_EXIT_CODE=$_rrd_rc
+_rrd_output_file="$_TMP_DIR/release_dry_output.txt"
+_rrd_rc=0
+cd "$_FAKE_REPO_DIR"
+PATH="$(pwd)/bin:${PATH}" sh workflows/release/release.sh --dry-run "$@" > "$_rrd_output_file" 2>&1 || _rrd_rc=$?
+cd "$_ORIG_DIR"
+_RUN_OUTPUT=$(cat "$_rrd_output_file")
+_RUN_EXIT_CODE=$_rrd_rc
 }
 
 # --- Summary ---
 
 print_summary() {
-    echo ""
-    printf "${_TH_BOLD}--- Test Summary ---${_TH_NC}\n"
-    printf "  Total:   %d\n" $_TESTS_TOTAL
-    printf "  ${_TH_GREEN}Passed:  %d${_TH_NC}\n" $_TESTS_PASSED
-    printf "  ${_TH_RED}Failed:  %d${_TH_NC}\n" $_TESTS_FAILED
-    printf "  ${_TH_YELLOW}Skipped: %d${_TH_NC}\n" $_TESTS_SKIPPED
-    echo ""
-    if [ $_TESTS_FAILED -gt 0 ]; then
-        printf "${_TH_RED}${_TH_BOLD}FAIL${_TH_NC}\n"
-        return 1
-    else
-        printf "${_TH_GREEN}${_TH_BOLD}PASS${_TH_NC}\n"
-        return 0
-    fi
+echo "" >&2
+printf "${_TH_BOLD}--- Test Summary ---${_TH_NC}\n" >&2
+printf " Total: %d\n" $_TESTS_TOTAL >&2
+printf " ${_TH_GREEN}Passed: %d${_TH_NC}\n" $_TESTS_PASSED >&2
+printf " ${_TH_RED}Failed: %d${_TH_NC}\n" $_TESTS_FAILED >&2
+printf " ${_TH_YELLOW}Skipped: %d${_TH_NC}\n" $_TESTS_SKIPPED >&2
+echo "" >&2
+if [ $_TESTS_FAILED -gt 0 ]; then
+printf "${_TH_RED}${_TH_BOLD}FAIL${_TH_NC}\n" >&2
+return 1
+else
+printf "${_TH_GREEN}${_TH_BOLD}PASS${_TH_NC}\n" >&2
+return 0
+fi
 }

--- a/workflows/release/__test__/test-new-flags.sh
+++ b/workflows/release/__test__/test-new-flags.sh
@@ -250,7 +250,7 @@ it "shows harness executable in dry-run with --auto"
     _FAKE_REPO_DIR="$_TMP_DIR/auto-harness"
     create_fake_repo "$_FAKE_REPO_DIR"
     run_release_dry 0.9.0 --auto
-    assert_contains "$_RUN_OUTPUT" "Harness: echo"
+    assert_contains "$_RUN_OUTPUT" "Harness: opencode (adapter: opencode)"
     test_pass
     cleanup_fake_repo "$_FAKE_REPO_DIR"
 

--- a/workflows/release/__test__/test-regression.sh
+++ b/workflows/release/__test__/test-regression.sh
@@ -164,12 +164,25 @@ it "allows --alpha with --skip-precommit"
 describe "Regression: .env parsing edge cases"
 
 it "handles .env with trailing whitespace in values"
-    _FAKE_REPO_DIR="$_TMP_DIR/reg-env-trail"
-    create_fake_repo "$_FAKE_REPO_DIR"
-    cd "$_FAKE_REPO_DIR"
-    printf 'RELEASE_HARNESS=echo\nRELEASE_HARNESS_MODEL=test-model\n' > .env
-    cd "$_ORIG_DIR"
-    run_release_dry 0.9.0 --auto
-    assert_contains "$_RUN_OUTPUT" "Harness: echo"
-    test_pass
-    cleanup_fake_repo "$_FAKE_REPO_DIR"
+_FAKE_REPO_DIR="$_TMP_DIR/reg-env-trail"
+create_fake_repo "$_FAKE_REPO_DIR"
+cd "$_FAKE_REPO_DIR"
+printf 'RELEASE_HARNESS=opencode\nRELEASE_HARNESS_MODEL=test-model\n' > .env
+cd "$_ORIG_DIR"
+run_release_dry 0.9.0 --auto
+assert_contains "$_RUN_OUTPUT" "Harness: opencode"
+test_pass
+cleanup_fake_repo "$_FAKE_REPO_DIR"
+
+it "rejects unsupported harness adapter"
+_FAKE_REPO_DIR="$_TMP_DIR/reg-unsupported-adapter"
+create_fake_repo "$_FAKE_REPO_DIR"
+cd "$_FAKE_REPO_DIR"
+printf 'RELEASE_HARNESS=fakeharness\nRELEASE_HARNESS_MODEL=test-model\n' > .env
+cd "$_ORIG_DIR"
+_output=$(cd "$_FAKE_REPO_DIR" && PATH="$(pwd)/bin:${PATH}" sh workflows/release/release.sh 0.9.0 --auto 2>&1) && _rc=0 || _rc=$?
+cd "$_ORIG_DIR"
+assert_exit_code 1 "$_rc"
+assert_contains "$_output" "not a supported adapter"
+test_pass
+cleanup_fake_repo "$_FAKE_REPO_DIR"

--- a/workflows/release/release.sh
+++ b/workflows/release/release.sh
@@ -7,12 +7,88 @@ PROMPT_TEMPLATE="$SCRIPT_DIR/release-readme-prompt.md"
 ENV_FILE="$PROJECT_ROOT/.env"
 CHANGELOG_FILE="$PROJECT_ROOT/CHANGELOG.md"
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[0;33m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-NC='\033[0m'
+if [ "${NO_COLOR:-}" ]; then
+    RED=""
+    GREEN=""
+    YELLOW=""
+    CYAN=""
+    BOLD=""
+    NC=""
+else
+    RED=$(printf '\033[0;31m')
+    GREEN=$(printf '\033[0;32m')
+    YELLOW=$(printf '\033[0;33m')
+    CYAN=$(printf '\033[0;36m')
+    BOLD=$(printf '\033[1m')
+    NC=$(printf '\033[0m')
+fi
+
+# --- Harness adapters ---
+# Each adapter implements: _harness_run_<name> and _harness_cleanup_<name>
+# To add a new adapter, implement both functions and register the name in
+# _HARNESS_ADAPTERS below.
+
+_HARNESS_ADAPTERS="opencode"
+
+_harness_adapter_name() {
+    case "$1" in
+    opencode) printf 'opencode' ;;
+    claude|claude-code) printf 'claude' ;;
+    codex) printf 'codex' ;;
+    hermes) printf 'hermes' ;;
+    openclaw) printf 'openclaw' ;;
+    antigravity) printf 'antigravity' ;;
+    *) printf '' ;;
+    esac
+}
+
+_harness_adapter_check() {
+    _ha_name=$(_harness_adapter_name "$1")
+    if [ -z "$_ha_name" ]; then
+        return 1
+    fi
+    case "$_ha_name" in
+    $_HARNESS_ADAPTERS) return 0 ;;
+    *) return 1 ;;
+    esac
+}
+
+# --- opencode adapter ---
+
+_harness_run_opencode() {
+    _hro_bin="$1"
+    _hro_model="$2"
+    _hro_args="$3"
+    _hro_title="$4"
+    _hro_prompt="$5"
+
+    _hro_output=$( \
+        OPENCODE= OPENCODE_PID= OPENCODE_RUN_ID= OPENCODE_PROCESS_ROLE= \
+        OPENCODE_SERVER_USERNAME= OPENCODE_SERVER_PASSWORD= \
+        "$_hro_bin" run \
+            --model "$_hro_model" \
+            $_hro_args \
+            --title "$_hro_title" \
+            --format json \
+            "$_hro_prompt" \
+            2>&1 \
+    ) && _hro_rc=0 || _hro_rc=$?
+
+    printf '%s' "$_hro_output"
+    return $_hro_rc
+}
+
+_harness_cleanup_opencode() {
+    _hco_bin="$1"
+    _hco_session_id="$2"
+    if [ -n "$_hco_session_id" ]; then
+        "$_hco_bin" session delete "$_hco_session_id" 2>/dev/null || true
+    fi
+}
+
+_harness_session_id_opencode() {
+    printf '%s' "$1" | sed -n 's/.*"sessionID":"\([^"]*\)".*/\1/p' | head -1
+}
 
 info() { printf "${CYAN}[INFO]${NC} %s\n" "$*"; }
 ok()   { printf "${GREEN}[OK]${NC} %s\n" "$*"; }
@@ -52,13 +128,16 @@ ${BOLD}Options${NC}
   --dry-run             Validate and generate changelog only, no mutations
   --auto                Enable AI-assisted README update via harness
   --strict              Compose with --auto to abort on harness failure
-  --harness <exec>      Override the harness executable (default: \$RELEASE_HARNESS from .env)
-  -h, --help            Show this help message
+--harness <exec> Override the harness executable (default: \$RELEASE_HARNESS from .env)
+ Must be a supported adapter: opencode
+ -h, --help Show this help message
 
 ${BOLD}Environment${NC} (loaded from .env)
-  RELEASE_HARNESS        Harness executable name (default: opencode)
-  RELEASE_HARNESS_MODEL  Model for harness (default: nvidia/z-ai/glm-5.1)
-  RELEASE_HARNESS_ARGS   Extra harness arguments (default: --dangerously-skip-permissions)
+RELEASE_HARNESS Harness executable name (default: opencode)
+ Must match a supported adapter
+RELEASE_HARNESS_MODEL Model for harness (default: nvidia/z-ai/glm-5.1)
+RELEASE_HARNESS_ARGS Extra harness arguments (default: --dangerously-skip-permissions)
+NO_COLOR Set to any value to disable colored output
 EOF
     exit 0
 }
@@ -347,9 +426,14 @@ PREV_TAG=$(git describe --tags --abbrev=0 HEAD 2>/dev/null) || die "No previous 
 
 AUTO_ENABLED=false
 if [ "$AUTO" = true ]; then
-    AUTO_ENABLED=true
-    HARNESS_BIN="${HARNESS_OVERRIDE:-$RELEASE_HARNESS}"
-    command -v "$HARNESS_BIN" >/dev/null 2>&1 || die "Harness executable '$HARNESS_BIN' not found in PATH"
+AUTO_ENABLED=true
+HARNESS_BIN="${HARNESS_OVERRIDE:-$RELEASE_HARNESS}"
+HARNESS_ADAPTER=$(_harness_adapter_name "$HARNESS_BIN")
+if [ -z "$HARNESS_ADAPTER" ]; then
+die "Harness '$HARNESS_BIN' is not a supported adapter. Supported: $(echo $_HARNESS_ADAPTERS | tr ' ' ', ')"
+fi
+_harness_adapter_check "$HARNESS_BIN" || die "Harness adapter '$HARNESS_ADAPTER' is not implemented yet. Implemented: $(echo $_HARNESS_ADAPTERS | tr ' ' ', ')"
+command -v "$HARNESS_BIN" >/dev/null 2>&1 || die "Harness executable '$HARNESS_BIN' not found in PATH"
 
     if [ -n "$NOTES_TEMPLATE" ]; then
         EFFECTIVE_TEMPLATE="$NOTES_TEMPLATE"
@@ -398,9 +482,9 @@ if [ -n "$NOTES_TEMPLATE" ]; then
     echo "  Notes template: ${NOTES_TEMPLATE}"
 fi
 if [ "$AUTO_ENABLED" = true ]; then
-    echo "  Harness: ${HARNESS_BIN}"
-    echo "  Model: ${RELEASE_HARNESS_MODEL}"
-    echo "  Strict: ${STRICT}"
+echo " Harness: ${HARNESS_BIN} (adapter: ${HARNESS_ADAPTER})"
+echo " Model: ${RELEASE_HARNESS_MODEL}"
+echo " Strict: ${STRICT}"
 fi
 echo ""
 
@@ -447,22 +531,37 @@ if [ "$AUTO_ENABLED" = true ]; then
         echo "  Would run harness with template: $EFFECTIVE_TEMPLATE"
         rm -f /tmp/release-readme-prompt-resolved.txt
     else
-        info "Invoking harness..."
+    info "Invoking harness..."
         HARNESS_PROMPT=$(cat /tmp/release-readme-prompt-resolved.txt)
         rm -f /tmp/release-readme-prompt-resolved.txt
 
-        if $HARNESS_BIN run --model "$RELEASE_HARNESS_MODEL" $RELEASE_HARNESS_ARGS "$HARNESS_PROMPT"; then
+        _HARNESS_SESSION_TITLE="release-automation-v${VERSION}"
+        _HARNESS_OUTPUT=$(_harness_run_"$HARNESS_ADAPTER" \
+            "$HARNESS_BIN" \
+            "$RELEASE_HARNESS_MODEL" \
+            "$RELEASE_HARNESS_ARGS" \
+            "$_HARNESS_SESSION_TITLE" \
+            "$HARNESS_PROMPT" \
+        ) && _HARNESS_RC=0 || _HARNESS_RC=$?
+
+        _HARNESS_SESSION_ID=$(_harness_session_id_"$HARNESS_ADAPTER" "$_HARNESS_OUTPUT")
+
+        if [ "$_HARNESS_RC" -eq 0 ]; then
             ok "Harness completed successfully"
+            _harness_cleanup_"$HARNESS_ADAPTER" "$HARNESS_BIN" "$_HARNESS_SESSION_ID"
+            if [ -n "$_HARNESS_SESSION_ID" ]; then
+                info "Harness session $_HARNESS_SESSION_ID archived"
+            fi
 
             if [ -n "$(git status --porcelain)" ]; then
                 die "Harness exited 0 but left uncommitted changes. Commit or stash them, then re-run."
             fi
         else
-            HARNESS_EXIT=$?
+            _harness_cleanup_"$HARNESS_ADAPTER" "$HARNESS_BIN" "$_HARNESS_SESSION_ID"
             if [ "$STRICT" = true ]; then
-                die "Harness exited with code ${HARNESS_EXIT} (--strict: aborting release)"
+                die "Harness exited with code ${_HARNESS_RC} (--strict: aborting release)"
             else
-                warn "Harness exited with code ${HARNESS_EXIT} (--auto: continuing without README update)"
+                warn "Harness exited with code ${_HARNESS_RC} (--auto: continuing without README update)"
                 if [ -n "$(git status --porcelain)" ]; then
                     warn "Harness left uncommitted changes. Resetting..."
                     git checkout -- .


### PR DESCRIPTION
## Summary

Fixes multiple issues in the release workflow scripts and adds a parallel test runner.

### ANSI Escape Fixes
- Replaced `RED='\033[0;31m'` style with `RED=$(printf '\033[0;31m')` in `release.sh`, `test-helper.sh`, and `run-tests.sh`
- In POSIX sh/dash, `printf` only interprets `\033` in format string literals, not when stored in variables
- Added `NO_COLOR` env var support — disables all colored output when set

### Harness Adapter Abstraction
- Added adapter infrastructure: `_HARNESS_ADAPTERS`, `_harness_adapter_name()`, `_harness_adapter_check()`
- Implemented `opencode` adapter with `_harness_run_opencode()`, `_harness_cleanup_opencode()`, `_harness_session_id_opencode()`
- Session isolation: unsets `OPENCODE*` env vars before `opencode run` to prevent "Session not found" errors
- Adapter validation: unsupported adapters rejected with error message

### Parallel Test Runner
- Rewrote `run-tests.sh` with `sh -c` isolation for background test suites
- Fixed trap inheritance issue: background `&` processes inherited parent EXIT trap, causing premature `$_TMP_DIR` cleanup
- TTY detection (`[ -t 1 ]`): TTY mode uses ANSI cursor-control + FIFO live streaming; non-TTY mode uses log capture with `[label]` prefixes
- Parallelism bounded by logical CPU cores (`getconf _NPROCESSORS_ONLN`), overridable via `MAX_PARALLEL` env var
- Rolling output buffer per suite (configurable via `_ROLL_LINES`, default 3)
- Summary displayed for all invocations: standalone, full parallel, and with-args runs

### Bug Fixes
- Fixed dash "Illegal option" error: `printf "${BOLD}--- Summary ---${NC}\n"` became `printf "--- Summary ---\n"` when NO_COLOR stripped ANSI codes, causing dash to interpret `---` as options. Split into `printf '%s' "..."` + `printf '\n'`

## Test plan

- [x] All 132 POSIX sh tests pass (test-args, test-dry-run, test-env, test-new-flags, test-preflight, test-regression, test-release-notes, test-version)
- [x] All 349 vitest tests pass
- [x] No circular dependencies
- [x] Pre-commit hooks pass (build:clean, check:fix, test, circular-dependencies)
- [x] GPG-signed commits
- [x] TTY and non-TTY output modes verified
- [x] `NO_COLOR=1` disables colored output
- [x] Unsupported adapter rejected with error
