### PR TITLE
fix(validator): resolve inline rule overload

### DIFF
--- a/src/validators/rules/__tests__/helpers/createInlineRule.spec.ts
+++ b/src/validators/rules/__tests__/helpers/createInlineRule.spec.ts
@@ -1,24 +1,44 @@
 import type { Custom } from '../../types/index.ts'
-import { createInlineRule } from '../../helpers/createInlineRule.ts'
+import { createInlineRule, type InlineRuleName } from '../../helpers/createInlineRule.ts'
 
 describe('createInlineRule', () => {
-    it('should support named rules when only the subject type is explicit', () => {
-        const hasLength: Custom<[], string, string> = createInlineRule<string>(
-            'hasLength',
-            value => value.length > 0
-        )
+  it('should support named rules when only the subject type is explicit', () => {
+    const hasLength: Custom<[], string, string> = createInlineRule<string>(
+      'hasLength',
+      value => value.length > 0
+    )
 
-        expect(hasLength[0]).toBe('hasLength')
-        expect(hasLength[2]('value')()).toBe(true)
-        expect(hasLength[2]('')()).toBe(false)
-    })
+    expect(hasLength[0]).toBe('hasLength')
+    expect(hasLength[2]('value')()).toBe(true)
+    expect(hasLength[2]('')()).toBe(false)
+  })
 
-    it('should preserve literal rule names when all type arguments are inferred', () => {
-        const hasLength: Custom<[], 'hasLength', string> = createInlineRule(
-            'hasLength',
-            (value: string) => value.length > 0
-        )
+  it('should preserve literal rule names when all type arguments are inferred', () => {
+    const hasLength: Custom<[], 'hasLength', string> = createInlineRule(
+      'hasLength',
+      (value: string) => value.length > 0
+    )
 
-        expect(hasLength[0]).toBe('hasLength')
-    })
+    expect(hasLength[0]).toBe('hasLength')
+  })
+
+  it('should return an anonymous rule name when no name is provided', () => {
+    const rule: Custom<[], InlineRuleName, string> = createInlineRule(
+      (value: string) => value.length > 0
+    )
+
+    expect(rule[0]).toBe('Custom.Rule.<anonymous>')
+    expect(rule[2]('value')()).toBe(true)
+    expect(rule[2]('')()).toBe(false)
+  })
+
+  it('should support anonymous rules when only the subject type is explicit', () => {
+    const rule: Custom<[], InlineRuleName, string> = createInlineRule<string>(
+      value => value.length > 0
+    )
+
+    expect(rule[0]).toBe('Custom.Rule.<anonymous>')
+    expect(rule[2]('value')()).toBe(true)
+    expect(rule[2]('')()).toBe(false)
+  })
 })

--- a/src/validators/rules/__tests__/helpers/createInlineRule.spec.ts
+++ b/src/validators/rules/__tests__/helpers/createInlineRule.spec.ts
@@ -1,0 +1,24 @@
+import type { Custom } from '../../types/index.ts'
+import { createInlineRule } from '../../helpers/createInlineRule.ts'
+
+describe('createInlineRule', () => {
+    it('should support named rules when only the subject type is explicit', () => {
+        const hasLength: Custom<[], string, string> = createInlineRule<string>(
+            'hasLength',
+            value => value.length > 0
+        )
+
+        expect(hasLength[0]).toBe('hasLength')
+        expect(hasLength[2]('value')()).toBe(true)
+        expect(hasLength[2]('')()).toBe(false)
+    })
+
+    it('should preserve literal rule names when all type arguments are inferred', () => {
+        const hasLength: Custom<[], 'hasLength', string> = createInlineRule(
+            'hasLength',
+            (value: string) => value.length > 0
+        )
+
+        expect(hasLength[0]).toBe('hasLength')
+    })
+})

--- a/src/validators/rules/__tests__/helpers/createInlineRule.spec.ts
+++ b/src/validators/rules/__tests__/helpers/createInlineRule.spec.ts
@@ -22,6 +22,17 @@ describe('createInlineRule', () => {
     expect(hasLength[0]).toBe('hasLength')
   })
 
+  it('should preserve literal rule names when both type arguments are explicit', () => {
+    const hasLength: Custom<[], 'hasLength', string> = createInlineRule<string, 'hasLength'>(
+      'hasLength',
+      value => value.length > 0
+    )
+
+    expect(hasLength[0]).toBe('hasLength')
+    expect(hasLength[2]('value')()).toBe(true)
+    expect(hasLength[2]('')()).toBe(false)
+  })
+
   it('should return an anonymous rule name when no name is provided', () => {
     const rule: Custom<[], InlineRuleName, string> = createInlineRule(
       (value: string) => value.length > 0
@@ -40,5 +51,32 @@ describe('createInlineRule', () => {
     expect(rule[0]).toBe('Custom.Rule.<anonymous>')
     expect(rule[2]('value')()).toBe(true)
     expect(rule[2]('')()).toBe(false)
+  })
+
+  describe('type inference', () => {
+    it('should infer literal rule name when all types are inferred', () => {
+      const rule = createInlineRule('hasLength', (value: string) => value.length > 0)
+      expectTypeOf(rule[0]).toEqualTypeOf<'hasLength'>()
+    })
+
+    it('should widen rule name to string when only TSubject is explicit', () => {
+      const rule = createInlineRule<string>('hasLength', value => value.length > 0)
+      expectTypeOf(rule[0]).toEqualTypeOf<string>()
+    })
+
+    it('should infer InlineRuleName for anonymous rules', () => {
+      const rule = createInlineRule((value: string) => value.length > 0)
+      expectTypeOf(rule[0]).toEqualTypeOf<InlineRuleName>()
+    })
+
+    it('should infer InlineRuleName for anonymous rules with explicit TSubject', () => {
+      const rule = createInlineRule<string>(value => value.length > 0)
+      expectTypeOf(rule[0]).toEqualTypeOf<InlineRuleName>()
+    })
+
+    it('should infer literal rule name when both type params are explicit', () => {
+      const rule = createInlineRule<string, 'hasLength'>('hasLength', value => value.length > 0)
+      expectTypeOf(rule[0]).toEqualTypeOf<'hasLength'>()
+    })
   })
 })

--- a/src/validators/rules/helpers/createInlineRule.ts
+++ b/src/validators/rules/helpers/createInlineRule.ts
@@ -1,7 +1,3 @@
-// export function createInlineRule<T>(rule: T): T {
-//     return rule
-// }
-
 import type { Fn } from '../../../types/Func.ts'
 import type { Custom } from '../types/index.ts'
 import { createRule } from './createRule.ts'
@@ -11,28 +7,31 @@ export const InlineRuleName = 'Custom.Rule.<anonymous>' as const
 export type InlineRuleName = typeof InlineRuleName
 
 export function createInlineRule<TSubject, TRuleName extends string>(
-    name: TRuleName,
-    predicate: Fn<[subject: TSubject], boolean>
+  name: TRuleName,
+  predicate: Fn<[subject: TSubject], boolean>
 ): Custom<[], TRuleName, TSubject>
 export function createInlineRule<TSubject>(
-    name: string,
-    predicate: Fn<[subject: TSubject], boolean>
+  name: string,
+  predicate: Fn<[subject: TSubject], boolean>
 ): Custom<[], string, TSubject>
 export function createInlineRule<TSubject>(
-    predicate: Fn<[subject: TSubject], boolean>
+  predicate: Fn<[subject: TSubject], boolean>
 ): Custom<[], InlineRuleName, TSubject>
 
 export function createInlineRule<TSubject>(
-    ...args:
-        | [predicate: Fn<[subject: TSubject], boolean>]
-        | [name: string, predicate: Fn<[subject: TSubject], boolean>]
+  ...args:
+    | [predicate: Fn<[subject: TSubject], boolean>]
+    | [name: string, predicate: Fn<[subject: TSubject], boolean>]
 ): Custom<[], string | InlineRuleName, TSubject> {
-    const [predicate, name = InlineRuleName] = args.reverse() as
-        | [predicate: Fn<[subject: TSubject], boolean>]
-        | [predicate: Fn<[subject: TSubject], boolean>, name: string]
-
+  if (args.length === 1) {
     return createRule({
-        name,
-        handler: createRuleHandler(predicate),
+      name: InlineRuleName,
+      handler: createRuleHandler(args[0]),
     })()
+  }
+
+  return createRule({
+    name: args[0],
+    handler: createRuleHandler(args[1]),
+  })()
 }

--- a/src/validators/rules/helpers/createInlineRule.ts
+++ b/src/validators/rules/helpers/createInlineRule.ts
@@ -10,13 +10,17 @@ import { createRuleHandler } from './createRuleHandler.ts'
 export const InlineRuleName = 'Custom.Rule.<anonymous>' as const
 export type InlineRuleName = typeof InlineRuleName
 
-export function createInlineRule<TSubject>(
-    predicate: Fn<[subject: TSubject], boolean>
-): Custom<[], InlineRuleName, TSubject>
 export function createInlineRule<TSubject, TRuleName extends string>(
     name: TRuleName,
     predicate: Fn<[subject: TSubject], boolean>
 ): Custom<[], TRuleName, TSubject>
+export function createInlineRule<TSubject>(
+    name: string,
+    predicate: Fn<[subject: TSubject], boolean>
+): Custom<[], string, TSubject>
+export function createInlineRule<TSubject>(
+    predicate: Fn<[subject: TSubject], boolean>
+): Custom<[], InlineRuleName, TSubject>
 
 export function createInlineRule<TSubject>(
     ...args:


### PR DESCRIPTION
## Summary
- Fix createInlineRule overload resolution for named rules when only TSubject is explicit
- Add regression coverage for createInlineRule<string>('name', predicate)
- Preserve existing runtime behavior

Closes #40

## Verification
- yarn run check
- yarn test
- yarn tsc -p tsconfig.json --noEmit
- yarn build