### PR TITLE
fix(schema): preserve optional schema metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,26 @@ const objectMaybeHasFoo = object({
 // if it hasn't then pass anyway as it is optional property.
 ```
 
+When using `object<T>({...})`, include every key from `T` in the schema tree. Optional
+properties in `T` must still be present in the tree with `.optional()` so the runtime validator
+knows which properties may be omitted:
+
+```typescript
+import { object, string } from '@srhenry/type-utils'
+
+interface Item {
+    id: string
+    name?: string
+}
+
+const isItem = object<Item>({
+    id: string(),
+    name: string().optional()
+})
+
+isItem({ id: 'item-1' }) // true
+```
+
 ### Schema helpers
 
 #### [`Schema.and`](https://srhenry.github.io/type-utils/variables/and.html)

--- a/TODO.md
+++ b/TODO.md
@@ -30,3 +30,9 @@
 ### UX & interactivity
 
 - Interactive mode: prompt for confirmation at each step
+
+## Schema / Validators
+
+### object()
+
+- Strict mode: `object<T>().strict()` or `FluentSchema.strict()` that rejects unknown properties at runtime (no extra keys beyond the validator tree)

--- a/src/validators/__tests__/object.spec.ts
+++ b/src/validators/__tests__/object.spec.ts
@@ -1,0 +1,25 @@
+import { object } from '../schema/object.ts'
+import { string } from '../schema/string.ts'
+
+describe('object', () => {
+    it('requires optional typed keys to be explicitly represented with optional schemas', () => {
+        interface Item {
+            id: string
+            name?: string
+        }
+
+        // @ts-expect-error object<T>() intentionally requires optional keys in ValidatorMap<T>.
+        object<Item>({
+            id: string(),
+        })
+
+        const schema = object<Item>({
+            id: string(),
+            name: string().optional(),
+        })
+
+        expect(schema({ id: 'item-1' })).toBe(true)
+        expect(schema({ id: 'item-1', name: 'Example' })).toBe(true)
+        expect(schema({ id: 'item-1', name: 1 })).toBe(false)
+    })
+})

--- a/src/validators/__tests__/object.spec.ts
+++ b/src/validators/__tests__/object.spec.ts
@@ -8,10 +8,15 @@ describe('object', () => {
             name?: string
         }
 
-        // @ts-expect-error object<T>() intentionally requires optional keys in ValidatorMap<T>.
-        object<Item>({
-            id: string(),
-        })
+        // Compile-time: omitting an optional key from object<T>() is a type error.
+        // Wrapped in a function so it never executes at runtime.
+        function _typeCheck() {
+            // @ts-expect-error object<T>() intentionally requires optional keys in ValidatorMap<T>.
+            object<Item>({
+                id: string(),
+            })
+        }
+        void _typeCheck
 
         const schema = object<Item>({
             id: string(),

--- a/src/validators/schema/helpers/__tests__/copyStructMetadata.spec.ts
+++ b/src/validators/schema/helpers/__tests__/copyStructMetadata.spec.ts
@@ -1,0 +1,50 @@
+import { string } from '../../../schema/string.ts'
+import { copyStructMetadata } from '../copyStructMetadata.ts'
+import { hasOptionalFlag } from '../optionalFlag.ts'
+import { setOptionalFlag } from '../optionalFlag.ts'
+import { hasStructMetadata } from '../hasStructMetadata.ts'
+
+describe('copyStructMetadata', () => {
+    it('preserves the optional flag from the source guard', () => {
+        const source = string().optional()
+        const target = (arg: unknown): arg is string => typeof arg === 'string'
+
+        expect(hasOptionalFlag(source)).toBe(true)
+        expect(hasOptionalFlag(target)).toBe(false)
+
+        const result = copyStructMetadata(source as any, target, {})
+
+        expect(hasOptionalFlag(result)).toBe(true)
+        expect(hasStructMetadata(result)).toBe(true)
+    })
+
+    it('does not set the optional flag when source is not optional', () => {
+        const source = string()
+        const target = (arg: unknown): arg is string => typeof arg === 'string'
+
+        expect(hasOptionalFlag(source)).toBe(false)
+
+        const result = copyStructMetadata(source as any, target, {})
+
+        expect(hasOptionalFlag(result)).toBe(false)
+        expect(hasStructMetadata(result)).toBe(true)
+    })
+
+    it('throws when source has no struct metadata', () => {
+        const source = (arg: unknown): arg is string => typeof arg === 'string'
+        const target = (arg: unknown): arg is string => typeof arg === 'string'
+
+        expect(() => copyStructMetadata(source as any, target, {})).toThrow(TypeError)
+    })
+
+    it('preserves the optional flag even when an optional guard is manually tagged', () => {
+        const source = string()
+        setOptionalFlag(source)
+
+        const target = (arg: unknown): arg is string => typeof arg === 'string'
+
+        const result = copyStructMetadata(source as any, target, {})
+
+        expect(hasOptionalFlag(result)).toBe(true)
+    })
+})

--- a/src/validators/schema/helpers/copyStructMetadata.ts
+++ b/src/validators/schema/helpers/copyStructMetadata.ts
@@ -4,6 +4,7 @@ import type { V3 } from '../types/index.ts'
 
 import { getStructMetadata } from './getStructMetadata.ts'
 import { hasStructMetadata } from './hasStructMetadata.ts'
+import { hasOptionalFlag, setOptionalFlag } from './optionalFlag.ts'
 import { setStructMetadata } from './setStructMetadata.ts'
 export function copyStructMetadata<Target>(
     source: TypeGuard<any>,
@@ -34,5 +35,9 @@ export function copyStructMetadata<T, Target>(
 
     const metadata = deepMerge(getStructMetadata(source), update)
 
-    return setStructMetadata(metadata as V3.AnyStruct, target as TypeGuard<T>) as Target
+    const taggedTarget = setStructMetadata(metadata as V3.AnyStruct, target as TypeGuard<T>)
+
+    if (hasOptionalFlag(source)) setOptionalFlag(taggedTarget)
+
+    return taggedTarget as Target
 }


### PR DESCRIPTION
## Summary
- Document that object<T> requires optional keys to be explicitly represented with .optional()
- Add regression coverage for omitted optional keys being rejected at compile time
- Preserve optional flags when schema metadata is copied so explicit .optional() accepts missing properties

Closes #41

## Verification
- yarn run check
- yarn test
- yarn tsc -p tsconfig.json --noEmit
- yarn build