### PR TITLE
fix(pipeline): wrap pipeAsync return in Awaited<U>

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@srhenry/type-utils",
-    "version": "0.8.2",
+    "version": "0.8.3",
     "description": "Type utilities for Typescript and also Javascript",
     "type": "module",
     "main": "./dist/cjs/index.js",

--- a/src/helpers/Experimental/pipeline/core/PipelineBox.ts
+++ b/src/helpers/Experimental/pipeline/core/PipelineBox.ts
@@ -26,6 +26,9 @@ export class PipelineBox<T> {
 
     pipe<U>(fn: (value: T) => Exclude<U, Promise<any>>): PipelineBox<U>
     pipe<U>(fn: (value: T) => Promise<U>): AsyncPipelineBox<U>
+    pipe<U>(
+        fn: (value: T) => U | Promise<U>
+    ): U extends Promise<any> ? AsyncPipelineBox<Awaited<U>> : PipelineBox<U>
     pipe<U>(fn: (value: T) => U | Promise<U>): PipelineBox<U> | AsyncPipelineBox<U> {
         if (isCallWithTransform(fn)) {
             const result = (this._value as (...args: any[]) => any)(...fn.__callWithArgs)
@@ -49,10 +52,10 @@ export class PipelineBox<T> {
         return new PipelineBox(result as U) as PipelineBox<U>
     }
 
-    pipeAsync<U>(fn: (value: T) => U | Promise<U>): AsyncPipelineBox<U> {
+    pipeAsync<U>(fn: (value: T) => U | Promise<U>): AsyncPipelineBox<Awaited<U>> {
         const result = fn(this._value)
         const promise = result instanceof Promise ? result : Promise.resolve(result)
-        return new AsyncPipelineBox(promise as Promise<U>)
+        return new AsyncPipelineBox(promise as Promise<Awaited<U>>)
     }
 
     tap(fn: (value: T) => void, options?: TapOptions): PipelineBox<T> {
@@ -93,6 +96,7 @@ export class AsyncPipelineBox<T> {
 
     pipe<U>(fn: (value: T) => Exclude<U, Promise<any>>): AsyncPipelineBox<U>
     pipe<U>(fn: (value: T) => Promise<U>): AsyncPipelineBox<U>
+    pipe<U>(fn: (value: T) => U | Promise<U>): AsyncPipelineBox<Awaited<U>>
     pipe<U>(fn: (value: T) => U | Promise<U>): AsyncPipelineBox<U> {
         return new AsyncPipelineBox(
             this._promise.then(v => {
@@ -113,8 +117,8 @@ export class AsyncPipelineBox<T> {
         )
     }
 
-    pipeAsync<U>(fn: (value: T) => U | Promise<U>): AsyncPipelineBox<U> {
-        return new AsyncPipelineBox(this._promise.then(fn))
+    pipeAsync<U>(fn: (value: T) => U | Promise<U>): AsyncPipelineBox<Awaited<U>> {
+        return new AsyncPipelineBox(this._promise.then(fn) as Promise<Awaited<U>>)
     }
 
     tap(fn: (value: T) => void, options?: TapOptions): AsyncPipelineBox<T> {

--- a/src/helpers/__tests__/pipeline.spec.ts
+++ b/src/helpers/__tests__/pipeline.spec.ts
@@ -340,6 +340,69 @@ describe('pipeAsync', () => {
 
         expect(result2).toBe('error')
     })
+
+    it('should flatten Awaited<U> when pipeAsync callback returns a sync/async union', async () => {
+        const maybeAsync = (cond: boolean): Promise<{ x: number }> | { x: number } =>
+            cond ? Promise.resolve({ x: 1 }) : { x: 2 }
+
+        const syncResult = await pipe(true)
+            .pipeAsync(maybeAsync)
+            .pipeAsync(v => v.x)
+            .depipe()
+
+        expect(syncResult).toBe(1)
+
+        const asyncResult = await pipe(Promise.resolve(false))
+            .pipeAsync(maybeAsync)
+            .pipeAsync(v => v.x)
+            .depipe()
+
+        expect(asyncResult).toBe(2)
+    })
+
+    it('should flatten Awaited<U> when pipeAsync on AsyncPipelineBox returns a sync/async union', async () => {
+        const maybeAsync = (cond: boolean): Promise<{ x: number }> | { x: number } =>
+            cond ? Promise.resolve({ x: 1 }) : { x: 2 }
+
+        const result = await pipe(Promise.resolve(true))
+            .pipeAsync(maybeAsync)
+            .pipeAsync(v => v.x)
+            .depipe()
+
+        expect(result).toBe(1)
+    })
+
+    it('should correctly type chained pipeAsync with mixed sync/async callbacks', async () => {
+        const step1 = (n: number) => n * 2
+        const step2 = (n: number): Promise<number> | number =>
+            n > 2 ? Promise.resolve(n + 10) : n + 1
+        const step3 = (n: number): Promise<string> | string =>
+            n > 10 ? Promise.resolve(`big: ${n}`) : `small: ${n}`
+
+        const resultSmall = await pipe(1)
+            .pipeAsync(step1)
+            .pipeAsync(step2)
+            .pipeAsync(step3)
+            .depipe()
+
+        expect(resultSmall).toBe('small: 3')
+
+        const resultBig = await pipe(5).pipeAsync(step1).pipeAsync(step2).pipeAsync(step3).depipe()
+
+        expect(resultBig).toBe('big: 20')
+    })
+
+    it('should flatten Awaited<U> in pipe catch-all overload with sync/async union', async () => {
+        const maybeAsync = (cond: boolean): Promise<{ x: number }> | { x: number } =>
+            cond ? Promise.resolve({ x: 1 }) : { x: 2 }
+
+        const result = await pipe(Promise.resolve(true))
+            .pipe(maybeAsync)
+            .pipeAsync(v => v.x)
+            .depipe()
+
+        expect(result).toBe(1)
+    })
 })
 
 describe('createPipeline', () => {


### PR DESCRIPTION
## Summary

Fixes #50 — `pipeAsync` captures `U` verbatim in `AsyncPipelineBox<U>`, losing the `Awaited<>` flattening from 0.7.x. When the callback returns a union like `Promise<A> | B`, the pipeline carried `AsyncPipelineBox<Promise<A> | B>` instead of `AsyncPipelineBox<A | B>`.

## Changes

### Core fix (`PipelineBox.ts`)
- **`PipelineBox.pipeAsync`**: Return type `AsyncPipelineBox<U>` → `AsyncPipelineBox<Awaited<U>>`
- **`AsyncPipelineBox.pipeAsync`**: Same fix
- **`PipelineBox.pipe` catch-all overload**: Return type `PipelineBox<U> | AsyncPipelineBox<U>` → `U extends Promise<any> ? AsyncPipelineBox<Awaited<U>> : PipelineBox<U>`
- **`AsyncPipelineBox.pipe` catch-all overload**: Return type `AsyncPipelineBox<U>` → `AsyncPipelineBox<Awaited<U>>`

Implementation signatures use a separate overload (not callable externally) to satisfy TS while keeping the body type-checkable.

### Tests (`pipeline.spec.ts`)
- `pipeAsync` with conditional-async callback (sync/async union) on `PipelineBox`
- `pipeAsync` with conditional-async callback on `AsyncPipelineBox`
- Chained `pipeAsync` with mixed sync/async callbacks
- `pipe` catch-all overload with conditional-async callback

### Version
- Bump to 0.8.3 (semver patch)

## Verification
- `yarn tsc -p tsconfig.json --noEmit` ✓
- `yarn tsc -p tsconfig.cjs.json --noEmit` ✓
- `yarn test` — 380 passed ✓
- `yarn build:clean` ✓
- `yarn format` ✓
- `yarn circular-dependencies` ✓