### PR TITLE
feat(schema): export schema types, GetSchema<T>, ValidateReturn, and rule types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,6 +347,8 @@ Use nested checkboxes for decomposition within a single task. If a sub-task grow
 - **NEVER silently overwrite established AGENTS.md guidelines** — always propose first and get confirmation, even when not in doubt.
 - **NEVER use `any` in production code** — Biome allows `any` in test files (`*.spec.ts`, `__tests__/`) only. Use proper types in `src/` code.
 - **NEVER push YAML/JSON without validating** — after editing any `.yml`, `.yaml`, or `.json` file, run `npx prettier --check <file>` before committing. YAML is indentation-sensitive; even one-space drift silently breaks CI.
+- **NEVER disable GPG commit signing** — do not use `-c commit.gpgsign=false`, `--no-gpg-sign`, or any other mechanism to bypass GPG signing. If GPG signing fails (e.g. pinentry timeout in headless sessions), stop work and wait for user input — do not work around it.
+- **NEVER continue past GPG pinentry failures** — if `git commit` hangs or errors due to GPG pinentry, stop all work immediately and wait for the user to resolve or provide direction. Do not retry with signing disabled.
 
 ## Important Notes
 

--- a/src/TypeGuards/helpers/asTypeGuard.ts
+++ b/src/TypeGuards/helpers/asTypeGuard.ts
@@ -1,6 +1,6 @@
 import type { Param0 } from '../../types/Func.ts'
 import type { Predicate } from '../../types/Predicate.ts'
-import type { CustomStruct } from '../../validators/schema/types/index.ts'
+import type { V3 } from '../../validators/schema/types/v3/index.ts'
 import type { TypeGuard } from '../types/index.ts'
 
 import { isRuleStruct } from '../../validators/schema/helpers/isRuleStruct.ts'
@@ -13,19 +13,19 @@ type OptionalizedKeys = 'rules'
 
 export function asTypeGuard<T>(
     predicate: Predicate<any>,
-    metadata?: Omit<CustomStruct<T>, OmittedKeys | OptionalizedKeys> &
-        Partial<Pick<CustomStruct<T>, OptionalizedKeys>>
+    metadata?: Omit<V3.CustomStruct<T>, OmittedKeys | OptionalizedKeys> &
+        Partial<Pick<V3.CustomStruct<T>, OptionalizedKeys>>
 ): TypeGuard<T>
 export function asTypeGuard<P extends Predicate<any>>(
     predicate: P,
-    metadata?: Omit<CustomStruct<Param0<P>>, OmittedKeys | OptionalizedKeys> &
-        Partial<Pick<CustomStruct<Param0<P>>, OptionalizedKeys>>
+    metadata?: Omit<V3.CustomStruct<Param0<P>>, OmittedKeys | OptionalizedKeys> &
+        Partial<Pick<V3.CustomStruct<Param0<P>>, OptionalizedKeys>>
 ): TypeGuard<Param0<P>>
 
 export function asTypeGuard<T>(
     predicate: Predicate<unknown>,
-    metadata: Omit<CustomStruct<T>, OmittedKeys | OptionalizedKeys> &
-        Partial<Pick<CustomStruct<T>, OptionalizedKeys>> = {}
+    metadata: Omit<V3.CustomStruct<T>, OmittedKeys | OptionalizedKeys> &
+        Partial<Pick<V3.CustomStruct<T>, OptionalizedKeys>> = {}
 ): TypeGuard<T> {
     if (!isUnaryFunction<TypeGuard>(predicate))
         throw new Error('predicate must be a unary function')
@@ -46,7 +46,7 @@ export function asTypeGuard<T>(
 
         type: 'custom',
         schema: predicate,
-    } as CustomStruct<T>
+    } as V3.CustomStruct<T>
 
     return setCustomStructMetadata<any>(struct, setAsTypeGuard(predicate))
 }

--- a/src/TypeGuards/helpers/isInstanceOf.ts
+++ b/src/TypeGuards/helpers/isInstanceOf.ts
@@ -1,5 +1,5 @@
 import { setStructMetadata } from '../../validators/schema/helpers/setStructMetadata.ts'
-import type { V3 } from '../../validators/schema/types/index.ts'
+import type { V3 } from '../../validators/schema/types/v3/index.ts'
 import type { ConstructorSignature } from '../types/index.ts'
 import { __curry_param__ } from './constants.ts'
 

--- a/src/match/__tests__/match.spec.ts
+++ b/src/match/__tests__/match.spec.ts
@@ -62,7 +62,7 @@ describe('match', () => {
                   bar: number
               }
             | {
-                  default: true
+                  default: boolean
                   data: { type: string }[]
               }
 

--- a/src/validators/SchemaValidator.ts
+++ b/src/validators/SchemaValidator.ts
@@ -1,7 +1,10 @@
 import type { MessageFormator, TypeGuard } from '../TypeGuards/types/index.ts'
 import type { Merge } from '../types/index.ts'
 import type { GenericStruct, V3 } from './schema/types/index.ts'
+import type { ValidateReturn } from './types/ValidateReturn.ts'
 import type { ValidatorMessageMap } from './types/index.ts'
+
+export type { ValidateReturn } from './types/ValidateReturn.ts'
 
 import { asTypeGuard } from '../TypeGuards/helpers/asTypeGuard.ts'
 import { getMetadata } from '../TypeGuards/helpers/getMetadata.ts'
@@ -21,14 +24,6 @@ import {
     validateUnion,
     validateDefault,
 } from './schema/helpers/validate/index.ts'
-
-export type ValidateReturn<T> =
-    | T
-    | ValidationErrors<
-          | ValidationError<unknown, T>
-          | ValidationError<unknown, T[Extract<keyof T, string>], Extract<keyof T, string>, T>
-          | ValidationError
-      >
 
 type ValidateOptionalArgs<Name extends string = string, Parent = any> = {
     name?: Name

--- a/src/validators/rules/index.ts
+++ b/src/validators/rules/index.ts
@@ -6,7 +6,26 @@ import { RecordRule, RecordRules } from './Record/index.ts'
 import { StringRule, StringRules } from './String/index.ts'
 
 export * from './helpers/index.ts'
-export * from './types/index.ts'
+
+// Explicit allowlist — prevents CUSTOM_RULE_BRAND (runtime internal symbol)
+// and RuleStruct (internal dispatch type) from reaching the public API.
+// Internal consumers still access these via ./types/index.ts directly.
+export type {
+    Rule,
+    Custom,
+    CustomHandler,
+    CustomFactory,
+    Default,
+    All,
+    CreateRuleArgs,
+    GetCustomRuleName,
+    GetCustomRuleArgs,
+    GetCustomRuleHandler,
+    GetCustomRuleFormator,
+    NoArgs,
+} from './types/index.ts'
+export type * from './types/RuleFactory.ts'
+export type * from './types/RuleTuple.ts'
 
 export {
     ArrayRule,

--- a/src/validators/schema/and.ts
+++ b/src/validators/schema/and.ts
@@ -1,9 +1,12 @@
 import type { TypeGuard } from '../../TypeGuards/types/index.ts'
 import type { Merge } from '../../types/index.ts'
 import type { Custom } from '../rules/types/index.ts'
-import type { StandardSchemaV1 } from '../standard-schema/types.ts'
 import type { V3 } from './types/index.ts'
-import type { FluentSchema } from './types/FluentSchema.ts'
+import type {
+    IntersectionSchema,
+    IntersectionSchemaEntry,
+    GetIntersectionEntryTypes,
+} from './types/IntersectionSchema.ts'
 
 import { getMessage } from '../../TypeGuards/helpers/getMessage.ts'
 import { useCustomRules } from '../rules/helpers/useCustomRules.ts'
@@ -17,17 +20,6 @@ import { setRuleMessage } from './helpers/setRuleMessage.ts'
 import { setStructMetadata } from './helpers/setStructMetadata.ts'
 import { validateCustomRules } from './helpers/validateCustomRules.ts'
 import { toStandardSchema } from '../standard-schema/toStandardSchema.ts'
-
-type IntersectionSchemaEntry<T = any> = TypeGuard<T> | StandardSchemaV1<T, T>
-
-type GetIntersectionEntryType<T> =
-    T extends TypeGuard<infer U> ? U : T extends StandardSchemaV1<infer U, any> ? U : never
-
-type GetIntersectionEntryTypes<T extends any[]> = T extends []
-    ? []
-    : T extends [infer U, ...infer V]
-      ? [GetIntersectionEntryType<U>, ...GetIntersectionEntryTypes<V>]
-      : any[]
 
 function _fn<T1, T2>(
     guard1: IntersectionSchemaEntry<T1>,
@@ -77,22 +69,6 @@ type OptionalizedAnd = {
 }
 
 export const _and = optionalizeOverloadFactory(_fn).optionalize<OptionalizedAnd>()
-
-type IntersectionSchema = CallableFunction & {
-    <T1, T2>(
-        guard1: IntersectionSchemaEntry<T1>,
-        guard2: IntersectionSchemaEntry<T2>
-    ): FluentSchema<T1 & T2>
-    <
-        TEntries extends [
-            IntersectionSchemaEntry<any>,
-            IntersectionSchemaEntry<any>,
-            ...IntersectionSchemaEntry[],
-        ],
-    >(
-        ...guards: TEntries
-    ): FluentSchema<V3.TIntersection<GetIntersectionEntryTypes<TEntries>>>
-}
 
 export const and: IntersectionSchema = ((
     guard1: IntersectionSchemaEntry<any>,

--- a/src/validators/schema/and.ts
+++ b/src/validators/schema/and.ts
@@ -1,7 +1,7 @@
 import type { TypeGuard } from '../../TypeGuards/types/index.ts'
 import type { Merge } from '../../types/index.ts'
 import type { Custom } from '../rules/types/index.ts'
-import type { V3 } from './types/index.ts'
+import type { V3 } from './types/v3/index.ts'
 import type {
     IntersectionSchema,
     IntersectionSchemaEntry,

--- a/src/validators/schema/any.ts
+++ b/src/validators/schema/any.ts
@@ -1,6 +1,6 @@
 import type { TypeGuard } from '../../TypeGuards/types/index.ts'
 import type { Custom } from '../rules/types/index.ts'
-import type { FluentSchema } from './types/FluentSchema.ts'
+import type { AnySchema } from './types/AnySchema.ts'
 
 import { toStandardSchema } from '../standard-schema/toStandardSchema.ts'
 import { useCustomRules } from '../rules/helpers/useCustomRules.ts'
@@ -22,8 +22,6 @@ function _fn(): TypeGuard<any> {
 }
 
 export const _any = optionalize(_fn)
-
-type AnySchema = CallableFunction & (() => FluentSchema<any>)
 
 export const any: AnySchema = (() => {
     const customRules: Custom<any[], string, any>[] = []

--- a/src/validators/schema/array.ts
+++ b/src/validators/schema/array.ts
@@ -2,7 +2,7 @@ import type { TypeGuard } from '../../TypeGuards/types/index.ts'
 import { ArrayRules, type ArrayRule } from '../rules/Array/index.ts'
 import type { Custom } from '../rules/types/index.ts'
 import type { ValidatorMap } from '../types/index.ts'
-import type { V3 } from './types/index.ts'
+import type { V3 } from './types/v3/index.ts'
 import type { ArraySchema } from './types/ArraySchema.ts'
 import type { StandardSchemaV1 } from '../standard-schema/types.ts'
 

--- a/src/validators/schema/asEnum.ts
+++ b/src/validators/schema/asEnum.ts
@@ -1,7 +1,7 @@
 import type { Generics } from '../../Generics/index.ts'
 import type { TypeGuard } from '../../TypeGuards/types/index.ts'
 import type { Custom } from '../rules/types/index.ts'
-import type { V3 } from './types/index.ts'
+import type { V3 } from './types/v3/index.ts'
 import type { EnumSchema } from './types/EnumSchema.ts'
 
 import { useCustomRules } from '../rules/helpers/useCustomRules.ts'

--- a/src/validators/schema/asEnum.ts
+++ b/src/validators/schema/asEnum.ts
@@ -2,7 +2,7 @@ import type { Generics } from '../../Generics/index.ts'
 import type { TypeGuard } from '../../TypeGuards/types/index.ts'
 import type { Custom } from '../rules/types/index.ts'
 import type { V3 } from './types/index.ts'
-import type { FluentSchema } from './types/FluentSchema.ts'
+import type { EnumSchema } from './types/EnumSchema.ts'
 
 import { useCustomRules } from '../rules/helpers/useCustomRules.ts'
 import { SchemaValidator } from '../SchemaValidator.ts'
@@ -41,9 +41,6 @@ function _fn<T extends Generics.PrimitiveType>(values: T[]): TypeGuard<T> {
 }
 
 export const _enum = optionalize(_fn)
-
-type EnumSchema = CallableFunction &
-    (<const T extends [...Generics.PrimitiveType[]]>(values: T) => FluentSchema<T[number]>)
 
 export const asEnum: EnumSchema = ((values: any[]) => {
     const customRules: Custom<any[], string, Generics.PrimitiveType>[] = []

--- a/src/validators/schema/asNull.ts
+++ b/src/validators/schema/asNull.ts
@@ -1,6 +1,6 @@
 import type { TypeGuard } from '../../TypeGuards/types/index.ts'
 import type { Custom } from '../rules/types/index.ts'
-import type { FluentSchema } from './types/FluentSchema.ts'
+import type { NullSchema } from './types/NullSchema.ts'
 
 import { toStandardSchema } from '../standard-schema/toStandardSchema.ts'
 import { useCustomRules } from '../rules/helpers/useCustomRules.ts'
@@ -23,8 +23,6 @@ function _fn(): TypeGuard<null> {
 }
 
 export const _null = optionalize(_fn)
-
-type NullSchema = CallableFunction & (() => FluentSchema<null>)
 
 export const asNull: NullSchema = (() => {
     const customRules: Custom<any[], string, null>[] = []

--- a/src/validators/schema/asUndefined.ts
+++ b/src/validators/schema/asUndefined.ts
@@ -1,6 +1,6 @@
 import type { TypeGuard } from '../../TypeGuards/types/index.ts'
 import type { Custom } from '../rules/types/index.ts'
-import type { FluentSchema } from './types/FluentSchema.ts'
+import type { UndefinedSchema } from './types/UndefinedSchema.ts'
 
 import { toStandardSchema } from '../standard-schema/toStandardSchema.ts'
 import { useCustomRules } from '../rules/helpers/useCustomRules.ts'
@@ -23,8 +23,6 @@ function _fn(): TypeGuard<undefined> {
 }
 
 export const _undefined = optionalize(_fn)
-
-type UndefinedSchema = CallableFunction & (() => FluentSchema<undefined>)
 
 export const asUndefined: UndefinedSchema = (() => {
     const customRules: Custom<any[], string, undefined>[] = []

--- a/src/validators/schema/boolean.ts
+++ b/src/validators/schema/boolean.ts
@@ -1,6 +1,6 @@
 import type { TypeGuard } from '../../TypeGuards/types/index.ts'
 import type { Custom } from '../rules/types/index.ts'
-import type { FluentSchema } from './types/FluentSchema.ts'
+import type { BooleanSchema } from './types/BooleanSchema.ts'
 
 import { toStandardSchema } from '../standard-schema/toStandardSchema.ts'
 import { useCustomRules } from '../rules/helpers/useCustomRules.ts'
@@ -24,8 +24,6 @@ function _fn(): TypeGuard<boolean> {
 }
 
 export const _boolean = optionalize(_fn)
-
-type BooleanSchema = CallableFunction & (() => FluentSchema<any>)
 
 export const boolean: BooleanSchema = (() => {
     const customRules: Custom<any[], string, boolean>[] = []

--- a/src/validators/schema/helpers/getStructMetadata.ts
+++ b/src/validators/schema/helpers/getStructMetadata.ts
@@ -1,6 +1,6 @@
 import type { Generics } from '../../../Generics/index.ts'
 import type { TypeGuard } from '../../../TypeGuards/types/index.ts'
-import type { V3 } from '../types/index.ts'
+import type { V3 } from '../types/v3/index.ts'
 
 import { getMetadata } from '../../../TypeGuards/helpers/getMetadata.ts'
 import { __metadata__ } from './constants.ts'

--- a/src/validators/schema/helpers/setCustomStructMetadata.ts
+++ b/src/validators/schema/helpers/setCustomStructMetadata.ts
@@ -1,5 +1,5 @@
 import type { TypeGuard } from '../../../TypeGuards/types/index.ts'
-import type { V3 } from '../types/index.ts'
+import type { V3 } from '../types/v3/index.ts'
 
 import { setMetadata } from '../../../TypeGuards/helpers/setMetadata.ts'
 import { __metadata__ } from './constants.ts'

--- a/src/validators/schema/helpers/setStructMetadata.ts
+++ b/src/validators/schema/helpers/setStructMetadata.ts
@@ -1,7 +1,7 @@
 import type Generics from '../../../Generics/index.ts'
 import type { TypeGuard } from '../../../TypeGuards/types/index.ts'
 import type { TypeFromArray } from '../../../types/index.ts'
-import type { V3 } from '../types/index.ts'
+import type { V3 } from '../types/v3/index.ts'
 
 import { setMetadata } from '../../../TypeGuards/helpers/setMetadata.ts'
 import { attachStandardSchema } from '../../standard-schema/attachStandardSchema.ts'

--- a/src/validators/schema/object.ts
+++ b/src/validators/schema/object.ts
@@ -1,7 +1,7 @@
 import type { TypeGuard } from '../../TypeGuards/types/index.ts'
 import type { Custom } from '../rules/types/index.ts'
 import type { Sanitize, NormalizedValidatorMap, ValidatorMap } from '../types/index.ts'
-import type { V3 } from './types/index.ts'
+import type { V3 } from './types/v3/index.ts'
 import type { ObjectSchema } from './types/ObjectSchema.ts'
 
 import { join } from '../../helpers/Experimental/join.ts'

--- a/src/validators/schema/object.ts
+++ b/src/validators/schema/object.ts
@@ -2,7 +2,7 @@ import type { TypeGuard } from '../../TypeGuards/types/index.ts'
 import type { Custom } from '../rules/types/index.ts'
 import type { Sanitize, NormalizedValidatorMap, ValidatorMap } from '../types/index.ts'
 import type { V3 } from './types/index.ts'
-import type { FluentSchema } from './types/FluentSchema.ts'
+import type { ObjectSchema } from './types/ObjectSchema.ts'
 
 import { join } from '../../helpers/Experimental/join.ts'
 import { map } from '../../helpers/Experimental/map.ts'
@@ -95,13 +95,6 @@ type OptionalizedObject = {
 }
 
 export const _object = optionalizeOverloadFactory(_fn).optionalize<OptionalizedObject>()
-
-type ObjectSchema = CallableFunction & {
-    <T extends {}>(tree: ValidatorMap<T>): FluentSchema<Sanitize<T>>
-    (): FluentSchema<Record<any, any>>
-    // biome-ignore lint/complexity/noBannedTypes: {} used as wildcard object type for overload
-    (tree: {}): FluentSchema<{}>
-}
 
 export const object: ObjectSchema = ((tree?: ValidatorMap<any>) => {
     const customRules: Custom<any[], string, object>[] = []

--- a/src/validators/schema/or.ts
+++ b/src/validators/schema/or.ts
@@ -1,8 +1,7 @@
 import type { TypeGuard } from '../../TypeGuards/types/index.ts'
 import type { Custom } from '../rules/types/index.ts'
-import type { StandardSchemaV1 } from '../standard-schema/types.ts'
 import type { V3 } from './types/index.ts'
-import type { FluentSchema } from './types/FluentSchema.ts'
+import type { UnionSchema, UnionSchemaEntry, GetUnionEntryTypes } from './types/UnionSchema.ts'
 
 import { getMessage } from '../../TypeGuards/helpers/getMessage.ts'
 import { useCustomRules } from '../rules/helpers/useCustomRules.ts'
@@ -16,17 +15,6 @@ import { setRuleMessage } from './helpers/setRuleMessage.ts'
 import { setStructMetadata } from './helpers/setStructMetadata.ts'
 import { validateCustomRules } from './helpers/validateCustomRules.ts'
 import { toStandardSchema } from '../standard-schema/toStandardSchema.ts'
-
-type UnionSchemaEntry<T = any> = TypeGuard<T> | StandardSchemaV1<T, T>
-
-type GetUnionEntryType<T> =
-    T extends TypeGuard<infer U> ? U : T extends StandardSchemaV1<infer U, any> ? U : never
-
-type GetUnionEntryTypes<T extends any[]> = T extends []
-    ? []
-    : T extends [infer U, ...infer V]
-      ? [GetUnionEntryType<U>, ...GetUnionEntryTypes<V>]
-      : any[]
 
 function _fn<T1, T2>(guard1: UnionSchemaEntry<T1>, guard2: UnionSchemaEntry<T2>): TypeGuard<T1 | T2>
 function _fn<TEntries extends UnionSchemaEntry[]>(
@@ -57,13 +45,6 @@ type OptionalizedOr = {
 }
 
 export const _or = optionalizeOverloadFactory(_fn).optionalize<OptionalizedOr>()
-
-type UnionSchema = CallableFunction & {
-    <T1, T2>(guard1: UnionSchemaEntry<T1>, guard2: UnionSchemaEntry<T2>): FluentSchema<T1 | T2>
-    <TEntries extends [UnionSchemaEntry<any>, UnionSchemaEntry<any>, ...UnionSchemaEntry[]]>(
-        guards: TEntries
-    ): FluentSchema<V3.TUnion<GetUnionEntryTypes<TEntries>>>
-}
 
 export const or: UnionSchema = ((
     guard1: UnionSchemaEntry<any>,

--- a/src/validators/schema/or.ts
+++ b/src/validators/schema/or.ts
@@ -1,6 +1,6 @@
 import type { TypeGuard } from '../../TypeGuards/types/index.ts'
 import type { Custom } from '../rules/types/index.ts'
-import type { V3 } from './types/index.ts'
+import type { V3 } from './types/v3/index.ts'
 import type { UnionSchema, UnionSchemaEntry, GetUnionEntryTypes } from './types/UnionSchema.ts'
 
 import { getMessage } from '../../TypeGuards/helpers/getMessage.ts'

--- a/src/validators/schema/primitive.ts
+++ b/src/validators/schema/primitive.ts
@@ -1,6 +1,6 @@
 import type { TypeGuard } from '../../TypeGuards/types/index.ts'
 import type { Custom } from '../rules/types/index.ts'
-import type { V3 } from './types/index.ts'
+import type { V3 } from './types/v3/index.ts'
 import type { PrimitiveSchema } from './types/PrimitiveSchema.ts'
 
 import { Generics } from '../../Generics/index.ts'

--- a/src/validators/schema/primitive.ts
+++ b/src/validators/schema/primitive.ts
@@ -1,7 +1,7 @@
 import type { TypeGuard } from '../../TypeGuards/types/index.ts'
 import type { Custom } from '../rules/types/index.ts'
 import type { V3 } from './types/index.ts'
-import type { FluentSchema } from './types/FluentSchema.ts'
+import type { PrimitiveSchema } from './types/PrimitiveSchema.ts'
 
 import { Generics } from '../../Generics/index.ts'
 import { toStandardSchema } from '../standard-schema/toStandardSchema.ts'
@@ -32,8 +32,6 @@ function _fn(): TypeGuard<Generics.PrimitiveType> {
 }
 
 export const _primitive = optionalize(_fn)
-
-type PrimitiveSchema = CallableFunction & (() => FluentSchema<Generics.PrimitiveType>)
 
 export const primitive: PrimitiveSchema = (() => {
     const customRules: Custom<any[], string, Generics.PrimitiveType>[] = []

--- a/src/validators/schema/record.ts
+++ b/src/validators/schema/record.ts
@@ -1,7 +1,7 @@
 import type { TypeGuard } from '../../TypeGuards/types/index.ts'
 import type { Custom } from '../rules/types/index.ts'
 import type { StandardSchemaV1 } from '../standard-schema/types.ts'
-import type { V3 } from './types/index.ts'
+import type { V3 } from './types/v3/index.ts'
 import type { RecordSchema } from './types/RecordSchema.ts'
 
 import { asTypeGuard } from '../../TypeGuards/helpers/asTypeGuard.ts'

--- a/src/validators/schema/symbol.ts
+++ b/src/validators/schema/symbol.ts
@@ -1,6 +1,6 @@
 import type { TypeGuard } from '../../TypeGuards/types/index.ts'
 import type { Custom } from '../rules/types/index.ts'
-import type { FluentSchema } from './types/FluentSchema.ts'
+import type { SymbolSchema } from './types/SymbolSchema.ts'
 
 import { toStandardSchema } from '../standard-schema/toStandardSchema.ts'
 import { useCustomRules } from '../rules/helpers/useCustomRules.ts'
@@ -34,8 +34,6 @@ function _fn(): TypeGuard<symbol> {
 type OptionalizedSymbol = () => TypeGuard<undefined | symbol>
 
 export const _symbol = optionalizeOverloadFactory(_fn).optionalize<OptionalizedSymbol>()
-
-type SymbolSchema = CallableFunction & (() => FluentSchema<symbol>)
 
 export const symbol: SymbolSchema = (() => {
     const customRules: Custom<any[], string, symbol>[] = []

--- a/src/validators/schema/tuple.ts
+++ b/src/validators/schema/tuple.ts
@@ -1,8 +1,7 @@
 import type { TypeGuard } from '../../TypeGuards/types/index.ts'
 import type { Custom } from '../rules/types/index.ts'
-import type { StandardSchemaV1 } from '../standard-schema/types.ts'
 import type { V3 } from './types/index.ts'
-import type { FluentSchema } from './types/FluentSchema.ts'
+import type { TupleSchema, TupleSchemaEntry } from './types/TupleSchema.ts'
 
 import { getMessage } from '../../TypeGuards/helpers/getMessage.ts'
 import { setMessage } from '../../TypeGuards/helpers/setMessage.ts'
@@ -17,8 +16,6 @@ import { optionalizeOverloadFactory } from './helpers/optional/index.ts'
 import { setStructMetadata } from './helpers/setStructMetadata.ts'
 import { validateCustomRules } from './helpers/validateCustomRules.ts'
 import { toStandardSchema } from '../standard-schema/toStandardSchema.ts'
-
-type TupleSchemaEntry<T = any> = TypeGuard<T> | StandardSchemaV1<T, T>
 
 const guardFactory =
     (schemas: TypeGuard<any>[]) =>
@@ -78,11 +75,6 @@ type OptionalizedTuple = CallableFunction & {
 }
 
 export const _tuple = optionalizeOverloadFactory(_fn).optionalize<OptionalizedTuple>()
-
-type TupleSchema = CallableFunction & {
-    <const T extends TupleSchemaEntry[]>(schemas: T): FluentSchema<V3.TypeGuardTupleUnwrap<T>>
-    <const T extends TupleSchemaEntry[]>(...schemas: T): FluentSchema<V3.TypeGuardTupleUnwrap<T>>
-}
 
 export const tuple: TupleSchema = ((
     _schema?: TupleSchemaEntry | TupleSchemaEntry[],

--- a/src/validators/schema/tuple.ts
+++ b/src/validators/schema/tuple.ts
@@ -1,6 +1,6 @@
 import type { TypeGuard } from '../../TypeGuards/types/index.ts'
 import type { Custom } from '../rules/types/index.ts'
-import type { V3 } from './types/index.ts'
+import type { V3 } from './types/v3/index.ts'
 import type { TupleSchema, TupleSchemaEntry } from './types/TupleSchema.ts'
 
 import { getMessage } from '../../TypeGuards/helpers/getMessage.ts'

--- a/src/validators/schema/types/AnySchema.ts
+++ b/src/validators/schema/types/AnySchema.ts
@@ -1,0 +1,3 @@
+import type { FluentSchema } from './FluentSchema.ts'
+
+export type AnySchema = CallableFunction & (() => FluentSchema<any>)

--- a/src/validators/schema/types/BooleanSchema.ts
+++ b/src/validators/schema/types/BooleanSchema.ts
@@ -1,3 +1,3 @@
 import type { FluentSchema } from './FluentSchema.ts'
 
-export type BooleanSchema = CallableFunction & (() => FluentSchema<any>)
+export type BooleanSchema = CallableFunction & (() => FluentSchema<boolean>)

--- a/src/validators/schema/types/BooleanSchema.ts
+++ b/src/validators/schema/types/BooleanSchema.ts
@@ -1,0 +1,3 @@
+import type { FluentSchema } from './FluentSchema.ts'
+
+export type BooleanSchema = CallableFunction & (() => FluentSchema<any>)

--- a/src/validators/schema/types/EnumSchema.ts
+++ b/src/validators/schema/types/EnumSchema.ts
@@ -1,0 +1,5 @@
+import type Generics from '../../../Generics/index.ts'
+import type { FluentSchema } from './FluentSchema.ts'
+
+export type EnumSchema = CallableFunction &
+    (<const T extends [...Generics.PrimitiveType[]]>(values: T) => FluentSchema<T[number]>)

--- a/src/validators/schema/types/FluentOptionalSchema.ts
+++ b/src/validators/schema/types/FluentOptionalSchema.ts
@@ -1,7 +1,7 @@
 import type { TypeGuard } from '../../../TypeGuards/index.ts'
 import type { Fn, ThrowFn } from '../../../types/Func.ts'
 import type { Custom } from '../../rules/types/index.ts'
-import type { ValidateReturn } from '../../SchemaValidator.ts'
+import type { ValidateReturn } from '../../types/ValidateReturn.ts'
 import type { ValidationErrors } from '../../ValidationErrors.ts'
 import type { StandardSchemaV1 } from '../../standard-schema/types.ts'
 

--- a/src/validators/schema/types/FluentSchema.ts
+++ b/src/validators/schema/types/FluentSchema.ts
@@ -2,7 +2,7 @@
 import type { TypeGuard } from '../../../TypeGuards/index.ts'
 import type { Fn, ThrowFn } from '../../../types/Func.ts'
 import type { Custom } from '../../rules/types/index.ts'
-import type { ValidateReturn } from '../../SchemaValidator.ts'
+import type { ValidateReturn } from '../../types/ValidateReturn.ts'
 import type { ValidationErrors } from '../../ValidationErrors.ts'
 import type { StandardSchemaV1 } from '../../standard-schema/types.ts'
 import type { FluentOptionalSchema } from './FluentOptionalSchema.ts'

--- a/src/validators/schema/types/FluentSchema.ts
+++ b/src/validators/schema/types/FluentSchema.ts
@@ -1,4 +1,3 @@
-// import type Generics from '../../../Generics/index.ts'
 import type { TypeGuard } from '../../../TypeGuards/index.ts'
 import type { Fn, ThrowFn } from '../../../types/Func.ts'
 import type { Custom } from '../../rules/types/index.ts'
@@ -6,12 +5,6 @@ import type { ValidateReturn } from '../../types/ValidateReturn.ts'
 import type { ValidationErrors } from '../../ValidationErrors.ts'
 import type { StandardSchemaV1 } from '../../standard-schema/types.ts'
 import type { FluentOptionalSchema } from './FluentOptionalSchema.ts'
-
-// type AppendMessageMethod<
-//     T,
-//     TRules extends { [x: string]: Fn<any[], any> } = {},
-//     TCalledRules extends [...(keyof TRules)[]] = []
-// > = T extends Generics.PrimitiveType? (message:string)=>FluentSchema<T, TRules, TCalledRules>
 
 export type FluentSchema<
     T,

--- a/src/validators/schema/types/GetSchema.ts
+++ b/src/validators/schema/types/GetSchema.ts
@@ -42,60 +42,60 @@ export type GetSchema<T> =
         ? FluentSchema<any>
         : // `unknown` extends nothing useful but also isn't a primitive — map to any schema
           unknown extends T
+          ? FluentSchema<any>
+          : // `void` doesn't extend any primitive or Record — map to any schema
+            // biome-ignore lint/suspicious/noConfusingVoidType: void used in conditional type check, not as a value type
+            [void] extends [T]
             ? FluentSchema<any>
-            : // `void` doesn't extend any primitive or Record — map to any schema
-              // biome-ignore lint/suspicious/noConfusingVoidType: void used in conditional type check, not as a value type
-              [void] extends [T]
-                ? FluentSchema<any>
-                : // `never` distributes through all branches and collapses — map to never (intentional)
-                  [never] extends [T]
-                    ? never
-                    : // Broad string type → string schema with all rules available
-                      [string] extends [T]
-                        ? T extends string
-                            ? FluentSchema<string, StringSchemaRules>
-                            : // Unreachable: [string] extends [T] is only true when T is at least
-                              // as wide as string. The only such types are `any` (caught above) and
-                              // `unknown` (caught above). The `never` here is a safety fallback.
-                              never
-                        : T extends string
-                          ? // String literal → all rules consumed (exact match overload)
-                            FluentSchema<string, StringSchemaRules, [...(keyof StringSchemaRules)[]]>
-                          : // Broad number type → number schema with all rules available
-                            [number] extends [T]
-                            ? T extends number
-                                ? FluentSchema<number, NumberSchemaRules>
-                                : // Unreachable: same reasoning as the string branch above.
-                                  never
-                            : T extends number
-                              ? // Numeric literal → all rules consumed
-                                FluentSchema<number, NumberSchemaRules, [...(keyof NumberSchemaRules)[]]>
-                              : T extends bigint
-                                ? FluentSchema<bigint, NumberSchemaRules>
-                                : T extends boolean
-                                  ? FluentSchema<boolean>
-                                  : T extends null
-                                    ? FluentSchema<null>
-                                    : T extends undefined
-                                      ? FluentSchema<undefined>
-                                      : T extends symbol
-                                        ? FluentSchema<symbol>
-                                        : // Tuple: checked before array (readonly [...] catches tuples but not generic arrays)
-                                          T extends readonly [infer _A, ...infer _B]
-                                          ? FluentSchema<T>
-                                          : // Array: generic T[]
-                                            T extends (infer U)[]
-                                            ? FluentSchema<U[], ArraySchemaRules>
-                                            : // Record (broad-keyed: string, number, or symbol keys) vs specific object
-                                              // PropertyKey (= string|number|symbol) can't be used directly because
-                                              // `symbol extends string` is false. Instead check each key type individually.
-                                              T extends Record<any, any>
-                                              ? string extends keyof T
-                                                ? FluentSchema<T, RecordSchemaRules>
-                                                : number extends keyof T
-                                                  ? FluentSchema<T, RecordSchemaRules>
-                                                  : symbol extends keyof T
-                                                    ? FluentSchema<T, RecordSchemaRules>
-                                                    : // Specific object: use Sanitize for optional prop normalization
-                                                      FluentSchema<Sanitize<T>>
-                                              : never
+            : // `never` distributes through all branches and collapses — map to never (intentional)
+              [never] extends [T]
+              ? never
+              : // Broad string type → string schema with all rules available
+                [string] extends [T]
+                ? T extends string
+                    ? FluentSchema<string, StringSchemaRules>
+                    : // Unreachable: [string] extends [T] is only true when T is at least
+                      // as wide as string. The only such types are `any` (caught above) and
+                      // `unknown` (caught above). The `never` here is a safety fallback.
+                      never
+                : T extends string
+                  ? // String literal → all rules consumed (exact match overload)
+                    FluentSchema<string, StringSchemaRules, [...(keyof StringSchemaRules)[]]>
+                  : // Broad number type → number schema with all rules available
+                    [number] extends [T]
+                    ? T extends number
+                        ? FluentSchema<number, NumberSchemaRules>
+                        : // Unreachable: same reasoning as the string branch above.
+                          never
+                    : T extends number
+                      ? // Numeric literal → all rules consumed
+                        FluentSchema<number, NumberSchemaRules, [...(keyof NumberSchemaRules)[]]>
+                      : T extends bigint
+                        ? FluentSchema<bigint, NumberSchemaRules>
+                        : T extends boolean
+                          ? FluentSchema<boolean>
+                          : T extends null
+                            ? FluentSchema<null>
+                            : T extends undefined
+                              ? FluentSchema<undefined>
+                              : T extends symbol
+                                ? FluentSchema<symbol>
+                                : // Tuple: checked before array (readonly [...] catches tuples but not generic arrays)
+                                  T extends readonly [infer _A, ...infer _B]
+                                  ? FluentSchema<T>
+                                  : // Array: generic T[]
+                                    T extends (infer U)[]
+                                    ? FluentSchema<U[], ArraySchemaRules>
+                                    : // Record (broad-keyed: string, number, or symbol keys) vs specific object
+                                      // PropertyKey (= string|number|symbol) can't be used directly because
+                                      // `symbol extends string` is false. Instead check each key type individually.
+                                      T extends Record<any, any>
+                                      ? string extends keyof T
+                                          ? FluentSchema<T, RecordSchemaRules>
+                                          : number extends keyof T
+                                            ? FluentSchema<T, RecordSchemaRules>
+                                            : symbol extends keyof T
+                                              ? FluentSchema<T, RecordSchemaRules>
+                                              : // Specific object: use Sanitize for optional prop normalization
+                                                FluentSchema<Sanitize<T>>
+                                      : never

--- a/src/validators/schema/types/GetSchema.ts
+++ b/src/validators/schema/types/GetSchema.ts
@@ -1,8 +1,8 @@
 import type { FluentSchema } from './FluentSchema.ts'
-import { StringRules } from '../../rules/String/index.ts'
-import { NumberRules } from '../../rules/Number/index.ts'
-import { ArrayRules } from '../../rules/Array/index.ts'
-import { RecordRules } from '../../rules/Record/index.ts'
+import type { StringRules } from '../../rules/String/index.ts'
+import type { NumberRules } from '../../rules/Number/index.ts'
+import type { ArrayRules } from '../../rules/Array/index.ts'
+import type { RecordRules } from '../../rules/Record/index.ts'
 import type { Sanitize } from '../../types/index.ts'
 
 type StringSchemaRules = Omit<typeof StringRules, 'optional'>

--- a/src/validators/schema/types/GetSchema.ts
+++ b/src/validators/schema/types/GetSchema.ts
@@ -15,6 +15,8 @@ type RecordSchemaRules = Omit<typeof RecordRules, 'optional'>
  * calling the corresponding schema builder function.
  *
  * @example
+ * GetSchema<any> → FluentSchema<any>
+ * GetSchema<unknown> → FluentSchema<any>
  * GetSchema<string> → FluentSchema<string, StringSchemaRules>
  * GetSchema<'hello'> → FluentSchema<string, StringSchemaRules, [...(keyof StringSchemaRules)[]]>
  * GetSchema<number> → FluentSchema<number, NumberSchemaRules>
@@ -26,47 +28,54 @@ type RecordSchemaRules = Omit<typeof RecordRules, 'optional'>
  * GetSchema<string[]> → FluentSchema<string[], ArraySchemaRules>
  * GetSchema<[string, number]> → FluentSchema<[string, number]>
  * GetSchema<Record<string, number>> → FluentSchema<Record<string, number>, RecordSchemaRules>
+ * GetSchema<Record<number, string>> → FluentSchema<Record<number, string>, RecordSchemaRules>
  * GetSchema<{ foo: string }> → FluentSchema<{ foo: string }>
  * GetSchema<{ foo?: string }> → FluentSchema<{ foo?: string }>
  * GetSchema<string | number> → FluentSchema<string | number>
  */
 export type GetSchema<T> =
-    // Broad string type → string schema with all rules available
-    [string] extends [T]
-        ? T extends string
-            ? FluentSchema<string, StringSchemaRules>
-            : never
-        : T extends string
-          ? // String literal → all rules consumed (exact match overload)
-            FluentSchema<string, StringSchemaRules, [...(keyof StringSchemaRules)[]]>
-          : // Broad number type → number schema with all rules available
-            [number] extends [T]
-            ? T extends number
-                ? FluentSchema<number, NumberSchemaRules>
+    // `any` distributes through every branch — detect it first to avoid mis-mapping
+    0 extends 1 & T
+        ? FluentSchema<any>
+        : // `unknown` extends nothing useful but also isn't a primitive — map to any schema
+          unknown extends T
+          ? FluentSchema<any>
+          : // Broad string type → string schema with all rules available
+            [string] extends [T]
+            ? T extends string
+                ? FluentSchema<string, StringSchemaRules>
                 : never
-            : T extends number
-              ? // Numeric literal → all rules consumed
-                FluentSchema<number, NumberSchemaRules, [...(keyof NumberSchemaRules)[]]>
-              : T extends bigint
-                ? FluentSchema<bigint, NumberSchemaRules>
-                : T extends boolean
-                  ? FluentSchema<boolean>
-                  : T extends null
-                    ? FluentSchema<null>
-                    : T extends undefined
-                      ? FluentSchema<undefined>
-                      : T extends symbol
-                        ? FluentSchema<symbol>
-                        : // Tuple: checked before array (readonly [...] catches tuples but not generic arrays)
-                          T extends readonly [infer _A, ...infer _B]
-                          ? FluentSchema<T>
-                          : // Array: generic T[]
-                            T extends (infer U)[]
-                            ? FluentSchema<U[], ArraySchemaRules>
-                            : // Record (all string keys) vs specific object
-                              T extends Record<any, any>
-                              ? string extends keyof T
-                                  ? FluentSchema<T, RecordSchemaRules>
-                                  : // Specific object: use Sanitize for optional prop normalization
-                                    FluentSchema<Sanitize<T>>
-                              : never
+            : T extends string
+              ? // String literal → all rules consumed (exact match overload)
+                FluentSchema<string, StringSchemaRules, [...(keyof StringSchemaRules)[]]>
+              : // Broad number type → number schema with all rules available
+                [number] extends [T]
+                ? T extends number
+                    ? FluentSchema<number, NumberSchemaRules>
+                    : never
+                : T extends number
+                  ? // Numeric literal → all rules consumed
+                    FluentSchema<number, NumberSchemaRules, [...(keyof NumberSchemaRules)[]]>
+                  : T extends bigint
+                    ? FluentSchema<bigint, NumberSchemaRules>
+                    : T extends boolean
+                      ? FluentSchema<boolean>
+                      : T extends null
+                        ? FluentSchema<null>
+                        : T extends undefined
+                          ? FluentSchema<undefined>
+                          : T extends symbol
+                            ? FluentSchema<symbol>
+                            : // Tuple: checked before array (readonly [...] catches tuples but not generic arrays)
+                              T extends readonly [infer _A, ...infer _B]
+                              ? FluentSchema<T>
+                              : // Array: generic T[]
+                                T extends (infer U)[]
+                                ? FluentSchema<U[], ArraySchemaRules>
+                                : // Record (broad key: string, number, or symbol) vs specific object
+                                  T extends Record<any, any>
+                                  ? PropertyKey extends keyof T
+                                      ? FluentSchema<T, RecordSchemaRules>
+                                      : // Specific object: use Sanitize for optional prop normalization
+                                        FluentSchema<Sanitize<T>>
+                                  : never

--- a/src/validators/schema/types/GetSchema.ts
+++ b/src/validators/schema/types/GetSchema.ts
@@ -37,36 +37,36 @@ export type GetSchema<T> =
             ? FluentSchema<string, StringSchemaRules>
             : never
         : T extends string
-          // String literal → all rules consumed (exact match overload)
-          ? FluentSchema<string, StringSchemaRules, [...(keyof StringSchemaRules)[]]>
+          ? // String literal → all rules consumed (exact match overload)
+            FluentSchema<string, StringSchemaRules, [...(keyof StringSchemaRules)[]]>
           : // Broad number type → number schema with all rules available
             [number] extends [T]
             ? T extends number
                 ? FluentSchema<number, NumberSchemaRules>
                 : never
             : T extends number
-              // Numeric literal → all rules consumed
-              ? FluentSchema<number, NumberSchemaRules, [...(keyof NumberSchemaRules)[]]>
+              ? // Numeric literal → all rules consumed
+                FluentSchema<number, NumberSchemaRules, [...(keyof NumberSchemaRules)[]]>
               : T extends bigint
-                  ? FluentSchema<bigint, NumberSchemaRules>
-                  : T extends boolean
-                      ? FluentSchema<boolean>
-                      : T extends null
-                          ? FluentSchema<null>
-                          : T extends undefined
-                              ? FluentSchema<undefined>
-                              : T extends symbol
-                                  ? FluentSchema<symbol>
-                                  : // Tuple: checked before array (readonly [...] catches tuples but not generic arrays)
-                                    T extends readonly [infer _A, ...infer _B]
-                                    ? FluentSchema<T>
-                                    : // Array: generic T[]
-                                      T extends (infer U)[]
-                                      ? FluentSchema<U[], ArraySchemaRules>
-                                      : // Record (all string keys) vs specific object
-                                        T extends Record<any, any>
-                                        ? string extends keyof T
-                                            ? FluentSchema<T, RecordSchemaRules>
-                                            : // Specific object: use Sanitize for optional prop normalization
-                                              FluentSchema<Sanitize<T>>
-                                        : never
+                ? FluentSchema<bigint, NumberSchemaRules>
+                : T extends boolean
+                  ? FluentSchema<boolean>
+                  : T extends null
+                    ? FluentSchema<null>
+                    : T extends undefined
+                      ? FluentSchema<undefined>
+                      : T extends symbol
+                        ? FluentSchema<symbol>
+                        : // Tuple: checked before array (readonly [...] catches tuples but not generic arrays)
+                          T extends readonly [infer _A, ...infer _B]
+                          ? FluentSchema<T>
+                          : // Array: generic T[]
+                            T extends (infer U)[]
+                            ? FluentSchema<U[], ArraySchemaRules>
+                            : // Record (all string keys) vs specific object
+                              T extends Record<any, any>
+                              ? string extends keyof T
+                                  ? FluentSchema<T, RecordSchemaRules>
+                                  : // Specific object: use Sanitize for optional prop normalization
+                                    FluentSchema<Sanitize<T>>
+                              : never

--- a/src/validators/schema/types/GetSchema.ts
+++ b/src/validators/schema/types/GetSchema.ts
@@ -28,12 +28,13 @@ type RecordSchemaRules = Omit<typeof RecordRules, 'optional'>
  * GetSchema<undefined> → FluentSchema<undefined>
  * GetSchema<symbol> → FluentSchema<symbol>
  * GetSchema<string[]> → FluentSchema<string[], ArraySchemaRules>
+ * GetSchema<readonly string[]> → FluentSchema<readonly string[], ArraySchemaRules>
  * GetSchema<[string, number]> → FluentSchema<[string, number]>
  * GetSchema<Record<string, number>> → FluentSchema<Record<string, number>, RecordSchemaRules>
  * GetSchema<Record<number, string>> → FluentSchema<Record<number, string>, RecordSchemaRules>
  * GetSchema<Record<symbol, boolean>> → FluentSchema<Record<symbol, boolean>, RecordSchemaRules>
- * GetSchema<{ foo: string }> → FluentSchema<{ foo: string }>
- * GetSchema<{ foo?: string }> → FluentSchema<{ foo?: string }>
+ * GetSchema<{ foo: string }> → FluentSchema<Sanitize<{ foo: string }>>
+ * GetSchema<{ foo?: string }> → FluentSchema<Sanitize<{ foo?: string }>>
  * GetSchema<string | number> → FluentSchema<string | number>
  */
 export type GetSchema<T> =
@@ -83,19 +84,22 @@ export type GetSchema<T> =
                                 : // Tuple: checked before array (readonly [...] catches tuples but not generic arrays)
                                   T extends readonly [infer _A, ...infer _B]
                                   ? FluentSchema<T>
-                                  : // Array: generic T[]
-                                    T extends (infer U)[]
-                                    ? FluentSchema<U[], ArraySchemaRules>
-                                    : // Record (broad-keyed: string, number, or symbol keys) vs specific object
-                                      // PropertyKey (= string|number|symbol) can't be used directly because
-                                      // `symbol extends string` is false. Instead check each key type individually.
-                                      T extends Record<any, any>
-                                      ? string extends keyof T
-                                          ? FluentSchema<T, RecordSchemaRules>
-                                          : number extends keyof T
+                                  : // Readonly array: checked before mutable array (readonly U[] doesn't extend U[])
+                                    T extends readonly (infer U)[]
+                                    ? FluentSchema<readonly U[], ArraySchemaRules>
+                                    : // Array: generic T[]
+                                      T extends (infer U)[]
+                                      ? FluentSchema<U[], ArraySchemaRules>
+                                      : // Record (broad-keyed: string, number, or symbol keys) vs specific object
+                                        // PropertyKey (= string|number|symbol) can't be used directly because
+                                        // `symbol extends string` is false. Instead check each key type individually.
+                                        T extends Record<any, any>
+                                        ? string extends keyof T
                                             ? FluentSchema<T, RecordSchemaRules>
-                                            : symbol extends keyof T
+                                            : number extends keyof T
                                               ? FluentSchema<T, RecordSchemaRules>
-                                              : // Specific object: use Sanitize for optional prop normalization
-                                                FluentSchema<Sanitize<T>>
-                                      : never
+                                              : symbol extends keyof T
+                                                ? FluentSchema<T, RecordSchemaRules>
+                                                : // Specific object: use Sanitize for optional prop normalization
+                                                  FluentSchema<Sanitize<T>>
+                                        : never

--- a/src/validators/schema/types/GetSchema.ts
+++ b/src/validators/schema/types/GetSchema.ts
@@ -1,0 +1,72 @@
+import type { FluentSchema } from './FluentSchema.ts'
+import { StringRules } from '../../rules/String/index.ts'
+import { NumberRules } from '../../rules/Number/index.ts'
+import { ArrayRules } from '../../rules/Array/index.ts'
+import { RecordRules } from '../../rules/Record/index.ts'
+import type { Sanitize } from '../../types/index.ts'
+
+type StringSchemaRules = Omit<typeof StringRules, 'optional'>
+type NumberSchemaRules = Omit<typeof NumberRules, 'optional'>
+type ArraySchemaRules = Omit<typeof ArrayRules, 'optional'>
+type RecordSchemaRules = Omit<typeof RecordRules, 'optional'>
+
+/**
+ * Maps a TypeScript type T to the FluentSchema result type you'd get from
+ * calling the corresponding schema builder function.
+ *
+ * @example
+ * GetSchema<string> → FluentSchema<string, StringSchemaRules>
+ * GetSchema<'hello'> → FluentSchema<string, StringSchemaRules, [...(keyof StringSchemaRules)[]]>
+ * GetSchema<number> → FluentSchema<number, NumberSchemaRules>
+ * GetSchema<bigint> → FluentSchema<bigint, NumberSchemaRules>
+ * GetSchema<boolean> → FluentSchema<boolean>
+ * GetSchema<null> → FluentSchema<null>
+ * GetSchema<undefined> → FluentSchema<undefined>
+ * GetSchema<symbol> → FluentSchema<symbol>
+ * GetSchema<string[]> → FluentSchema<string[], ArraySchemaRules>
+ * GetSchema<[string, number]> → FluentSchema<[string, number]>
+ * GetSchema<Record<string, number>> → FluentSchema<Record<string, number>, RecordSchemaRules>
+ * GetSchema<{ foo: string }> → FluentSchema<{ foo: string }>
+ * GetSchema<{ foo?: string }> → FluentSchema<{ foo?: string }>
+ * GetSchema<string | number> → FluentSchema<string | number>
+ */
+export type GetSchema<T> =
+    // Broad string type → string schema with all rules available
+    [string] extends [T]
+        ? T extends string
+            ? FluentSchema<string, StringSchemaRules>
+            : never
+        : T extends string
+          // String literal → all rules consumed (exact match overload)
+          ? FluentSchema<string, StringSchemaRules, [...(keyof StringSchemaRules)[]]>
+          : // Broad number type → number schema with all rules available
+            [number] extends [T]
+            ? T extends number
+                ? FluentSchema<number, NumberSchemaRules>
+                : never
+            : T extends number
+              // Numeric literal → all rules consumed
+              ? FluentSchema<number, NumberSchemaRules, [...(keyof NumberSchemaRules)[]]>
+              : T extends bigint
+                  ? FluentSchema<bigint, NumberSchemaRules>
+                  : T extends boolean
+                      ? FluentSchema<boolean>
+                      : T extends null
+                          ? FluentSchema<null>
+                          : T extends undefined
+                              ? FluentSchema<undefined>
+                              : T extends symbol
+                                  ? FluentSchema<symbol>
+                                  : // Tuple: checked before array (readonly [...] catches tuples but not generic arrays)
+                                    T extends readonly [infer _A, ...infer _B]
+                                    ? FluentSchema<T>
+                                    : // Array: generic T[]
+                                      T extends (infer U)[]
+                                      ? FluentSchema<U[], ArraySchemaRules>
+                                      : // Record (all string keys) vs specific object
+                                        T extends Record<any, any>
+                                        ? string extends keyof T
+                                            ? FluentSchema<T, RecordSchemaRules>
+                                            : // Specific object: use Sanitize for optional prop normalization
+                                              FluentSchema<Sanitize<T>>
+                                        : never

--- a/src/validators/schema/types/GetSchema.ts
+++ b/src/validators/schema/types/GetSchema.ts
@@ -17,6 +17,8 @@ type RecordSchemaRules = Omit<typeof RecordRules, 'optional'>
  * @example
  * GetSchema<any> → FluentSchema<any>
  * GetSchema<unknown> → FluentSchema<any>
+ * GetSchema<void> → FluentSchema<any>
+ * GetSchema<never> → never
  * GetSchema<string> → FluentSchema<string, StringSchemaRules>
  * GetSchema<'hello'> → FluentSchema<string, StringSchemaRules, [...(keyof StringSchemaRules)[]]>
  * GetSchema<number> → FluentSchema<number, NumberSchemaRules>
@@ -29,6 +31,7 @@ type RecordSchemaRules = Omit<typeof RecordRules, 'optional'>
  * GetSchema<[string, number]> → FluentSchema<[string, number]>
  * GetSchema<Record<string, number>> → FluentSchema<Record<string, number>, RecordSchemaRules>
  * GetSchema<Record<number, string>> → FluentSchema<Record<number, string>, RecordSchemaRules>
+ * GetSchema<Record<symbol, boolean>> → FluentSchema<Record<symbol, boolean>, RecordSchemaRules>
  * GetSchema<{ foo: string }> → FluentSchema<{ foo: string }>
  * GetSchema<{ foo?: string }> → FluentSchema<{ foo?: string }>
  * GetSchema<string | number> → FluentSchema<string | number>
@@ -39,43 +42,60 @@ export type GetSchema<T> =
         ? FluentSchema<any>
         : // `unknown` extends nothing useful but also isn't a primitive — map to any schema
           unknown extends T
-          ? FluentSchema<any>
-          : // Broad string type → string schema with all rules available
-            [string] extends [T]
-            ? T extends string
-                ? FluentSchema<string, StringSchemaRules>
-                : never
-            : T extends string
-              ? // String literal → all rules consumed (exact match overload)
-                FluentSchema<string, StringSchemaRules, [...(keyof StringSchemaRules)[]]>
-              : // Broad number type → number schema with all rules available
-                [number] extends [T]
-                ? T extends number
-                    ? FluentSchema<number, NumberSchemaRules>
-                    : never
-                : T extends number
-                  ? // Numeric literal → all rules consumed
-                    FluentSchema<number, NumberSchemaRules, [...(keyof NumberSchemaRules)[]]>
-                  : T extends bigint
-                    ? FluentSchema<bigint, NumberSchemaRules>
-                    : T extends boolean
-                      ? FluentSchema<boolean>
-                      : T extends null
-                        ? FluentSchema<null>
-                        : T extends undefined
-                          ? FluentSchema<undefined>
-                          : T extends symbol
-                            ? FluentSchema<symbol>
-                            : // Tuple: checked before array (readonly [...] catches tuples but not generic arrays)
-                              T extends readonly [infer _A, ...infer _B]
-                              ? FluentSchema<T>
-                              : // Array: generic T[]
-                                T extends (infer U)[]
-                                ? FluentSchema<U[], ArraySchemaRules>
-                                : // Record (broad key: string, number, or symbol) vs specific object
-                                  T extends Record<any, any>
-                                  ? PropertyKey extends keyof T
-                                      ? FluentSchema<T, RecordSchemaRules>
-                                      : // Specific object: use Sanitize for optional prop normalization
-                                        FluentSchema<Sanitize<T>>
-                                  : never
+            ? FluentSchema<any>
+            : // `void` doesn't extend any primitive or Record — map to any schema
+              // biome-ignore lint/suspicious/noConfusingVoidType: void used in conditional type check, not as a value type
+              [void] extends [T]
+                ? FluentSchema<any>
+                : // `never` distributes through all branches and collapses — map to never (intentional)
+                  [never] extends [T]
+                    ? never
+                    : // Broad string type → string schema with all rules available
+                      [string] extends [T]
+                        ? T extends string
+                            ? FluentSchema<string, StringSchemaRules>
+                            : // Unreachable: [string] extends [T] is only true when T is at least
+                              // as wide as string. The only such types are `any` (caught above) and
+                              // `unknown` (caught above). The `never` here is a safety fallback.
+                              never
+                        : T extends string
+                          ? // String literal → all rules consumed (exact match overload)
+                            FluentSchema<string, StringSchemaRules, [...(keyof StringSchemaRules)[]]>
+                          : // Broad number type → number schema with all rules available
+                            [number] extends [T]
+                            ? T extends number
+                                ? FluentSchema<number, NumberSchemaRules>
+                                : // Unreachable: same reasoning as the string branch above.
+                                  never
+                            : T extends number
+                              ? // Numeric literal → all rules consumed
+                                FluentSchema<number, NumberSchemaRules, [...(keyof NumberSchemaRules)[]]>
+                              : T extends bigint
+                                ? FluentSchema<bigint, NumberSchemaRules>
+                                : T extends boolean
+                                  ? FluentSchema<boolean>
+                                  : T extends null
+                                    ? FluentSchema<null>
+                                    : T extends undefined
+                                      ? FluentSchema<undefined>
+                                      : T extends symbol
+                                        ? FluentSchema<symbol>
+                                        : // Tuple: checked before array (readonly [...] catches tuples but not generic arrays)
+                                          T extends readonly [infer _A, ...infer _B]
+                                          ? FluentSchema<T>
+                                          : // Array: generic T[]
+                                            T extends (infer U)[]
+                                            ? FluentSchema<U[], ArraySchemaRules>
+                                            : // Record (broad-keyed: string, number, or symbol keys) vs specific object
+                                              // PropertyKey (= string|number|symbol) can't be used directly because
+                                              // `symbol extends string` is false. Instead check each key type individually.
+                                              T extends Record<any, any>
+                                              ? string extends keyof T
+                                                ? FluentSchema<T, RecordSchemaRules>
+                                                : number extends keyof T
+                                                  ? FluentSchema<T, RecordSchemaRules>
+                                                  : symbol extends keyof T
+                                                    ? FluentSchema<T, RecordSchemaRules>
+                                                    : // Specific object: use Sanitize for optional prop normalization
+                                                      FluentSchema<Sanitize<T>>
+                                              : never

--- a/src/validators/schema/types/IntersectionSchema.ts
+++ b/src/validators/schema/types/IntersectionSchema.ts
@@ -1,6 +1,6 @@
 import type { TypeGuard } from '../../../TypeGuards/types/index.ts'
 import type { StandardSchemaV1 } from '../../standard-schema/types.ts'
-import type { V3 } from './index.ts'
+import type { TIntersection } from './v3/index.ts'
 import type { FluentSchema } from './FluentSchema.ts'
 
 export type IntersectionSchemaEntry<T = any> = TypeGuard<T> | StandardSchemaV1<T, T>
@@ -27,5 +27,5 @@ export type IntersectionSchema = CallableFunction & {
         ],
     >(
         ...guards: TEntries
-    ): FluentSchema<V3.TIntersection<GetIntersectionEntryTypes<TEntries>>>
+    ): FluentSchema<TIntersection<GetIntersectionEntryTypes<TEntries>>>
 }

--- a/src/validators/schema/types/IntersectionSchema.ts
+++ b/src/validators/schema/types/IntersectionSchema.ts
@@ -1,0 +1,31 @@
+import type { TypeGuard } from '../../../TypeGuards/types/index.ts'
+import type { StandardSchemaV1 } from '../../standard-schema/types.ts'
+import type { V3 } from './index.ts'
+import type { FluentSchema } from './FluentSchema.ts'
+
+export type IntersectionSchemaEntry<T = any> = TypeGuard<T> | StandardSchemaV1<T, T>
+
+type GetIntersectionEntryType<T> =
+    T extends TypeGuard<infer U> ? U : T extends StandardSchemaV1<infer U, any> ? U : never
+
+export type GetIntersectionEntryTypes<T extends any[]> = T extends []
+    ? []
+    : T extends [infer U, ...infer V]
+      ? [GetIntersectionEntryType<U>, ...GetIntersectionEntryTypes<V>]
+      : any[]
+
+export type IntersectionSchema = CallableFunction & {
+    <T1, T2>(
+        guard1: IntersectionSchemaEntry<T1>,
+        guard2: IntersectionSchemaEntry<T2>
+    ): FluentSchema<T1 & T2>
+    <
+        TEntries extends [
+            IntersectionSchemaEntry<any>,
+            IntersectionSchemaEntry<any>,
+            ...IntersectionSchemaEntry[],
+        ],
+    >(
+        ...guards: TEntries
+    ): FluentSchema<V3.TIntersection<GetIntersectionEntryTypes<TEntries>>>
+}

--- a/src/validators/schema/types/NullSchema.ts
+++ b/src/validators/schema/types/NullSchema.ts
@@ -1,0 +1,3 @@
+import type { FluentSchema } from './FluentSchema.ts'
+
+export type NullSchema = CallableFunction & (() => FluentSchema<null>)

--- a/src/validators/schema/types/ObjectSchema.ts
+++ b/src/validators/schema/types/ObjectSchema.ts
@@ -1,0 +1,9 @@
+import type { FluentSchema } from './FluentSchema.ts'
+import type { Sanitize, ValidatorMap } from '../../types/index.ts'
+
+export type ObjectSchema = CallableFunction & {
+    <T extends {}>(tree: ValidatorMap<T>): FluentSchema<Sanitize<T>>
+    (): FluentSchema<Record<any, any>>
+    // biome-ignore lint/complexity/noBannedTypes: {} used as wildcard object type for overload
+    (tree: {}): FluentSchema<{}>
+}

--- a/src/validators/schema/types/PrimitiveSchema.ts
+++ b/src/validators/schema/types/PrimitiveSchema.ts
@@ -1,0 +1,4 @@
+import type { Generics } from '../../../Generics/index.ts'
+import type { FluentSchema } from './FluentSchema.ts'
+
+export type PrimitiveSchema = CallableFunction & (() => FluentSchema<Generics.PrimitiveType>)

--- a/src/validators/schema/types/SymbolSchema.ts
+++ b/src/validators/schema/types/SymbolSchema.ts
@@ -1,0 +1,3 @@
+import type { FluentSchema } from './FluentSchema.ts'
+
+export type SymbolSchema = CallableFunction & (() => FluentSchema<symbol>)

--- a/src/validators/schema/types/TupleSchema.ts
+++ b/src/validators/schema/types/TupleSchema.ts
@@ -1,11 +1,11 @@
 import type { TypeGuard } from '../../../TypeGuards/types/index.ts'
 import type { StandardSchemaV1 } from '../../standard-schema/types.ts'
-import type { V3 } from './index.ts'
+import type { TypeGuardTupleUnwrap } from './v3/index.ts'
 import type { FluentSchema } from './FluentSchema.ts'
 
 export type TupleSchemaEntry<T = any> = TypeGuard<T> | StandardSchemaV1<T, T>
 
 export type TupleSchema = CallableFunction & {
-    <const T extends TupleSchemaEntry[]>(schemas: T): FluentSchema<V3.TypeGuardTupleUnwrap<T>>
-    <const T extends TupleSchemaEntry[]>(...schemas: T): FluentSchema<V3.TypeGuardTupleUnwrap<T>>
+    <const T extends TupleSchemaEntry[]>(schemas: T): FluentSchema<TypeGuardTupleUnwrap<T>>
+    <const T extends TupleSchemaEntry[]>(...schemas: T): FluentSchema<TypeGuardTupleUnwrap<T>>
 }

--- a/src/validators/schema/types/TupleSchema.ts
+++ b/src/validators/schema/types/TupleSchema.ts
@@ -1,0 +1,11 @@
+import type { TypeGuard } from '../../../TypeGuards/types/index.ts'
+import type { StandardSchemaV1 } from '../../standard-schema/types.ts'
+import type { V3 } from './index.ts'
+import type { FluentSchema } from './FluentSchema.ts'
+
+export type TupleSchemaEntry<T = any> = TypeGuard<T> | StandardSchemaV1<T, T>
+
+export type TupleSchema = CallableFunction & {
+    <const T extends TupleSchemaEntry[]>(schemas: T): FluentSchema<V3.TypeGuardTupleUnwrap<T>>
+    <const T extends TupleSchemaEntry[]>(...schemas: T): FluentSchema<V3.TypeGuardTupleUnwrap<T>>
+}

--- a/src/validators/schema/types/UndefinedSchema.ts
+++ b/src/validators/schema/types/UndefinedSchema.ts
@@ -1,0 +1,3 @@
+import type { FluentSchema } from './FluentSchema.ts'
+
+export type UndefinedSchema = CallableFunction & (() => FluentSchema<undefined>)

--- a/src/validators/schema/types/UnionSchema.ts
+++ b/src/validators/schema/types/UnionSchema.ts
@@ -1,6 +1,6 @@
 import type { TypeGuard } from '../../../TypeGuards/types/index.ts'
 import type { StandardSchemaV1 } from '../../standard-schema/types.ts'
-import type { V3 } from './index.ts'
+import type { TUnion } from './v3/index.ts'
 import type { FluentSchema } from './FluentSchema.ts'
 
 export type UnionSchemaEntry<T = any> = TypeGuard<T> | StandardSchemaV1<T, T>
@@ -18,5 +18,5 @@ export type UnionSchema = CallableFunction & {
     <T1, T2>(guard1: UnionSchemaEntry<T1>, guard2: UnionSchemaEntry<T2>): FluentSchema<T1 | T2>
     <TEntries extends [UnionSchemaEntry<any>, UnionSchemaEntry<any>, ...UnionSchemaEntry[]]>(
         guards: TEntries
-    ): FluentSchema<V3.TUnion<GetUnionEntryTypes<TEntries>>>
+    ): FluentSchema<TUnion<GetUnionEntryTypes<TEntries>>>
 }

--- a/src/validators/schema/types/UnionSchema.ts
+++ b/src/validators/schema/types/UnionSchema.ts
@@ -1,0 +1,22 @@
+import type { TypeGuard } from '../../../TypeGuards/types/index.ts'
+import type { StandardSchemaV1 } from '../../standard-schema/types.ts'
+import type { V3 } from './index.ts'
+import type { FluentSchema } from './FluentSchema.ts'
+
+export type UnionSchemaEntry<T = any> = TypeGuard<T> | StandardSchemaV1<T, T>
+
+type GetUnionEntryType<T> =
+    T extends TypeGuard<infer U> ? U : T extends StandardSchemaV1<infer U, any> ? U : never
+
+export type GetUnionEntryTypes<T extends any[]> = T extends []
+    ? []
+    : T extends [infer U, ...infer V]
+      ? [GetUnionEntryType<U>, ...GetUnionEntryTypes<V>]
+      : any[]
+
+export type UnionSchema = CallableFunction & {
+    <T1, T2>(guard1: UnionSchemaEntry<T1>, guard2: UnionSchemaEntry<T2>): FluentSchema<T1 | T2>
+    <TEntries extends [UnionSchemaEntry<any>, UnionSchemaEntry<any>, ...UnionSchemaEntry[]]>(
+        guards: TEntries
+    ): FluentSchema<V3.TUnion<GetUnionEntryTypes<TEntries>>>
+}

--- a/src/validators/schema/types/__tests__/GetSchema.spec.ts
+++ b/src/validators/schema/types/__tests__/GetSchema.spec.ts
@@ -23,6 +23,7 @@ import type {
 import type { RuleStruct } from '../../../rules/types/index.ts'
 import type { FluentSchema } from '../FluentSchema.ts'
 import type { Sanitize } from '../../../types/index.ts'
+import type { RecordRules } from '../../../rules/Record/index.ts'
 
 describe('GetSchema', () => {
     it('should be importable', () => {
@@ -39,6 +40,21 @@ describe('Exported schema types are importable', () => {
 // Compile-time type assertions — verified by tsc --noEmit
 // Assert<T, U> forces U extends T; if not, compilation fails
 type Assert<T, U extends T> = U
+
+// Strict equality assertion: exact type match (both directions)
+type AssertExact<T, U> = [T] extends [U] ? ([U] extends [T] ? true : false) : false
+
+// GetSchema<any> → FluentSchema<any> (not FluentSchema<string, ...>)
+type GSAny = Assert<FluentSchema<any>, GetSchema<any>>
+
+// GetSchema<unknown> → FluentSchema<any> (catch-all, same as any schema)
+type GSUnknown = Assert<FluentSchema<any>, GetSchema<unknown>>
+
+// GetSchema<void> → FluentSchema<any>
+type GSVoid = Assert<FluentSchema<any>, GetSchema<void>>
+
+// GetSchema<never> → never (intentional — never inputs produce never output)
+type GSNever = AssertExact<GetSchema<never>, never>
 
 // GetSchema<string> → FluentSchema<string, StringSchemaRules>
 type GSString = Assert<FluentSchema<string, any, any[]>, GetSchema<string>>
@@ -74,40 +90,49 @@ type GSStringArray = Assert<FluentSchema<string[], any, any[]>, GetSchema<string
 type GSTuple = Assert<FluentSchema<[string, number]>, GetSchema<[string, number]>>
 
 // GetSchema<Record<string, number>> → FluentSchema<Record<string, number>, RecordSchemaRules>
-type GSRecord = Assert<
-    FluentSchema<Record<string, number>, any, any[]>,
-    GetSchema<Record<string, number>>
+// Strict: verify RecordSchemaRules is present (not {}), ensuring .nonEmpty() is available
+type RecordSchemaRules = Omit<typeof RecordRules, 'optional'>
+type GSRecord = Assert<FluentSchema<Record<string, number>, RecordSchemaRules, []>, GetSchema<Record<string, number>>>
+
+// GetSchema<Record<number, string>> → FluentSchema<Record<number, string>, RecordSchemaRules>
+// Strict: verify RecordSchemaRules is present for number-keyed records too
+type GSRecordNumberKey = Assert<
+    FluentSchema<Record<number, string>, RecordSchemaRules, []>,
+    GetSchema<Record<number, string>>
+>
+
+// GetSchema<Record<symbol, boolean>> → FluentSchema<Record<symbol, boolean>, RecordSchemaRules>
+// Strict: verify RecordSchemaRules is present for symbol-keyed records
+type GSRecordSymbolKey = Assert<
+    FluentSchema<Record<symbol, boolean>, RecordSchemaRules, []>,
+    GetSchema<Record<symbol, boolean>>
 >
 
 // GetSchema<{ foo: string }> → FluentSchema<Sanitize<{ foo: string }>>
 type GSObject = Assert<FluentSchema<Sanitize<{ foo: string }>>, GetSchema<{ foo: string }>>
 
 // GetSchema<{ foo?: string }> → FluentSchema<Sanitize<{ foo?: string }>>
-type GSOptionalObject = Assert<
-    FluentSchema<Sanitize<{ foo?: string }>>,
-    GetSchema<{ foo?: string }>
->
+type GSOptionalObject = Assert<FluentSchema<Sanitize<{ foo?: string }>>, GetSchema<{ foo?: string }>>
 
 // GetSchema<string | number> → FluentSchema<string | number>
 type GSUnion = Assert<FluentSchema<string | number>, GetSchema<string | number>>
 
-// GetSchema<any> → FluentSchema<any> (not FluentSchema<string, ...>)
-type GSAny = Assert<FluentSchema<any>, GetSchema<any>>
+// Negative test: GetSchema<() => void> → never (functions not supported)
+type GSFunction = AssertExact<GetSchema<() => void>, never>
 
-// GetSchema<unknown> → FluentSchema<any> (catch-all, same as any schema)
-type GSUnknown = Assert<FluentSchema<any>, GetSchema<unknown>>
+// Negative test: GetSchema<Date> → never (class instances not supported)
+type GSDate = AssertExact<GetSchema<Date>, never>
 
-// GetSchema<Record<number, string>> → FluentSchema<Record<number, string>, RecordSchemaRules>
-type GSRecordNumberKey = Assert<
-    FluentSchema<Record<number, string>, any, any[]>,
-    GetSchema<Record<number, string>>
->
-
-// GetSchema never returns never for valid inputs
-type _GSNeverCheck = Assert<never, never>
+// Verify Record types have .nonEmpty() method available
+type _recordHasNonEmpty = 'nonEmpty' extends keyof GetSchema<Record<string, number>> ? true : false
+type _assertNonEmpty = Assert<true, _recordHasNonEmpty>
 
 // Reference all type aliases to suppress noUnusedLocals
 const _type_checks: [
+    GSAny,
+    GSUnknown,
+    GSVoid,
+    GSNever,
     GSString,
     GSStringLiteral,
     GSNumber,
@@ -120,13 +145,15 @@ const _type_checks: [
     GSStringArray,
     GSTuple,
     GSRecord,
+    GSRecordNumberKey,
+    GSRecordSymbolKey,
     GSObject,
     GSOptionalObject,
     GSUnion,
-    GSAny,
-    GSUnknown,
-    GSRecordNumberKey,
-    _GSNeverCheck,
+    GSFunction,
+    GSDate,
+    _recordHasNonEmpty,
+    _assertNonEmpty,
 ] = null as any
 void _type_checks
 

--- a/src/validators/schema/types/__tests__/GetSchema.spec.ts
+++ b/src/validators/schema/types/__tests__/GetSchema.spec.ts
@@ -1,0 +1,133 @@
+import type { GetSchema } from '../index.ts'
+import type {
+    BooleanSchema,
+    NullSchema,
+    UndefinedSchema,
+    SymbolSchema,
+    AnySchema,
+    PrimitiveSchema,
+    EnumSchema,
+    ObjectSchema,
+    TupleSchema,
+    UnionSchema,
+    IntersectionSchema,
+    UnionSchemaEntry,
+    IntersectionSchemaEntry,
+    TupleSchemaEntry,
+    ValidateReturn,
+    Custom,
+    CustomFactory,
+    Rule,
+    RuleStruct,
+    CreateRuleArgs,
+} from '../index.ts'
+import type { FluentSchema } from '../FluentSchema.ts'
+
+describe('GetSchema', () => {
+    it('should be importable', () => {
+        expect(true).toBe(true)
+    })
+})
+
+describe('Exported schema types are importable', () => {
+    it('should import all schema builder types', () => {
+        expect(true).toBe(true)
+    })
+})
+
+// Compile-time type assertions — verified by tsc --noEmit
+// Assert<T, U> forces U extends T; if not, compilation fails
+type Assert<T, U extends T> = U
+
+// GetSchema<string> → FluentSchema<string, StringSchemaRules>
+type GSString = Assert<FluentSchema<string, any, any[]>, GetSchema<string>>
+
+// GetSchema<'hello'> → FluentSchema<string, StringSchemaRules, [...(keyof StringSchemaRules)[]]>
+type GSStringLiteral = GetSchema<'hello'>
+
+// GetSchema<number> → FluentSchema<number, NumberSchemaRules>
+type GSNumber = Assert<FluentSchema<number, any, any[]>, GetSchema<number>>
+
+// GetSchema<42> → FluentSchema<number, NumberSchemaRules, [...(keyof NumberSchemaRules)[]]>
+type GSNumberLiteral = GetSchema<42>
+
+// GetSchema<bigint> → FluentSchema<bigint, NumberSchemaRules>
+type GSBigint = Assert<FluentSchema<bigint, any, any[]>, GetSchema<bigint>>
+
+// GetSchema<boolean> → FluentSchema<boolean>
+type GSBoolean = Assert<FluentSchema<boolean>, GetSchema<boolean>>
+
+// GetSchema<null> → FluentSchema<null>
+type GSNull = Assert<FluentSchema<null>, GetSchema<null>>
+
+// GetSchema<undefined> → FluentSchema<undefined>
+type GSUndefined = Assert<FluentSchema<undefined>, GetSchema<undefined>>
+
+// GetSchema<symbol> → FluentSchema<symbol>
+type GSSymbol = Assert<FluentSchema<symbol>, GetSchema<symbol>>
+
+// GetSchema<string[]> → FluentSchema<string[], ArraySchemaRules>
+type GSStringArray = Assert<FluentSchema<string[], any, any[]>, GetSchema<string[]>>
+
+// GetSchema<[string, number]> → FluentSchema<[string, number]>
+type GSTuple = Assert<FluentSchema<[string, number]>, GetSchema<[string, number]>>
+
+// GetSchema<Record<string, number>> → FluentSchema<Record<string, number>, RecordSchemaRules>
+type GSRecord = Assert<
+    FluentSchema<Record<string, number>, any, any[]>,
+    GetSchema<Record<string, number>>
+>
+
+// GetSchema<{ foo: string }> → FluentSchema<Sanitize<{ foo: string }>>
+type GSObject = GetSchema<{ foo: string }>
+
+// GetSchema<{ foo?: string }> → FluentSchema<Sanitize<{ foo?: string }>>
+type GSOptionalObject = GetSchema<{ foo?: string }>
+
+// GetSchema<string | number> → FluentSchema<string | number>
+type GSUnion = Assert<FluentSchema<string | number>, GetSchema<string | number>>
+
+// Reference all type aliases to suppress noUnusedLocals
+const _type_checks: [
+    GSString,
+    GSStringLiteral,
+    GSNumber,
+    GSNumberLiteral,
+    GSBigint,
+    GSBoolean,
+    GSNull,
+    GSUndefined,
+    GSSymbol,
+    GSStringArray,
+    GSTuple,
+    GSRecord,
+    GSObject,
+    GSOptionalObject,
+    GSUnion,
+] = null as any
+void _type_checks
+
+// Reference imported schema types to verify they're importable
+const _schema_type_refs: [
+    BooleanSchema,
+    NullSchema,
+    UndefinedSchema,
+    SymbolSchema,
+    AnySchema,
+    PrimitiveSchema,
+    EnumSchema,
+    ObjectSchema,
+    TupleSchema,
+    UnionSchema,
+    IntersectionSchema,
+    UnionSchemaEntry,
+    IntersectionSchemaEntry,
+    TupleSchemaEntry,
+    ValidateReturn<unknown>,
+    Custom<[], '', unknown>,
+    CustomFactory<[]>,
+    Rule,
+    RuleStruct<any>,
+    CreateRuleArgs,
+] = null as any
+void _schema_type_refs

--- a/src/validators/schema/types/__tests__/GetSchema.spec.ts
+++ b/src/validators/schema/types/__tests__/GetSchema.spec.ts
@@ -18,9 +18,9 @@ import type {
     Custom,
     CustomFactory,
     Rule,
-    RuleStruct,
     CreateRuleArgs,
 } from '../index.ts'
+import type { RuleStruct } from '../../../rules/types/index.ts'
 import type { FluentSchema } from '../FluentSchema.ts'
 import type { Sanitize } from '../../../types/index.ts'
 

--- a/src/validators/schema/types/__tests__/GetSchema.spec.ts
+++ b/src/validators/schema/types/__tests__/GetSchema.spec.ts
@@ -91,6 +91,18 @@ type GSOptionalObject = Assert<
 // GetSchema<string | number> → FluentSchema<string | number>
 type GSUnion = Assert<FluentSchema<string | number>, GetSchema<string | number>>
 
+// GetSchema<any> → FluentSchema<any> (not FluentSchema<string, ...>)
+type GSAny = Assert<FluentSchema<any>, GetSchema<any>>
+
+// GetSchema<unknown> → FluentSchema<any> (catch-all, same as any schema)
+type GSUnknown = Assert<FluentSchema<any>, GetSchema<unknown>>
+
+// GetSchema<Record<number, string>> → FluentSchema<Record<number, string>, RecordSchemaRules>
+type GSRecordNumberKey = Assert<
+    FluentSchema<Record<number, string>, any, any[]>,
+    GetSchema<Record<number, string>>
+>
+
 // GetSchema never returns never for valid inputs
 type _GSNeverCheck = Assert<never, never>
 
@@ -111,6 +123,9 @@ const _type_checks: [
     GSObject,
     GSOptionalObject,
     GSUnion,
+    GSAny,
+    GSUnknown,
+    GSRecordNumberKey,
     _GSNeverCheck,
 ] = null as any
 void _type_checks

--- a/src/validators/schema/types/__tests__/GetSchema.spec.ts
+++ b/src/validators/schema/types/__tests__/GetSchema.spec.ts
@@ -20,7 +20,7 @@ import type {
     Rule,
     CreateRuleArgs,
 } from '../index.ts'
-import type { RuleStruct } from '../../../rules/types/index.ts'
+import type { RuleStruct } from '../../../rules/types/index.ts' // internal path — RuleStruct excluded from public API
 import type { FluentSchema } from '../FluentSchema.ts'
 import type { Sanitize } from '../../../types/index.ts'
 import type { RecordRules } from '../../../rules/Record/index.ts'
@@ -86,6 +86,12 @@ type GSSymbol = Assert<FluentSchema<symbol>, GetSchema<symbol>>
 // GetSchema<string[]> → FluentSchema<string[], ArraySchemaRules>
 type GSStringArray = Assert<FluentSchema<string[], any, any[]>, GetSchema<string[]>>
 
+// GetSchema<readonly string[]> → FluentSchema<readonly string[], ArraySchemaRules>
+type GSReadonlyStringArray = Assert<
+    FluentSchema<readonly string[], any, any[]>,
+    GetSchema<readonly string[]>
+>
+
 // GetSchema<[string, number]> → FluentSchema<[string, number]>
 type GSTuple = Assert<FluentSchema<[string, number]>, GetSchema<[string, number]>>
 
@@ -149,6 +155,7 @@ const _type_checks: [
     GSUndefined,
     GSSymbol,
     GSStringArray,
+    GSReadonlyStringArray,
     GSTuple,
     GSRecord,
     GSRecordNumberKey,

--- a/src/validators/schema/types/__tests__/GetSchema.spec.ts
+++ b/src/validators/schema/types/__tests__/GetSchema.spec.ts
@@ -92,7 +92,10 @@ type GSTuple = Assert<FluentSchema<[string, number]>, GetSchema<[string, number]
 // GetSchema<Record<string, number>> → FluentSchema<Record<string, number>, RecordSchemaRules>
 // Strict: verify RecordSchemaRules is present (not {}), ensuring .nonEmpty() is available
 type RecordSchemaRules = Omit<typeof RecordRules, 'optional'>
-type GSRecord = Assert<FluentSchema<Record<string, number>, RecordSchemaRules, []>, GetSchema<Record<string, number>>>
+type GSRecord = Assert<
+    FluentSchema<Record<string, number>, RecordSchemaRules, []>,
+    GetSchema<Record<string, number>>
+>
 
 // GetSchema<Record<number, string>> → FluentSchema<Record<number, string>, RecordSchemaRules>
 // Strict: verify RecordSchemaRules is present for number-keyed records too
@@ -112,7 +115,10 @@ type GSRecordSymbolKey = Assert<
 type GSObject = Assert<FluentSchema<Sanitize<{ foo: string }>>, GetSchema<{ foo: string }>>
 
 // GetSchema<{ foo?: string }> → FluentSchema<Sanitize<{ foo?: string }>>
-type GSOptionalObject = Assert<FluentSchema<Sanitize<{ foo?: string }>>, GetSchema<{ foo?: string }>>
+type GSOptionalObject = Assert<
+    FluentSchema<Sanitize<{ foo?: string }>>,
+    GetSchema<{ foo?: string }>
+>
 
 // GetSchema<string | number> → FluentSchema<string | number>
 type GSUnion = Assert<FluentSchema<string | number>, GetSchema<string | number>>

--- a/src/validators/schema/types/__tests__/GetSchema.spec.ts
+++ b/src/validators/schema/types/__tests__/GetSchema.spec.ts
@@ -22,6 +22,7 @@ import type {
     CreateRuleArgs,
 } from '../index.ts'
 import type { FluentSchema } from '../FluentSchema.ts'
+import type { Sanitize } from '../../../types/index.ts'
 
 describe('GetSchema', () => {
     it('should be importable', () => {
@@ -43,13 +44,13 @@ type Assert<T, U extends T> = U
 type GSString = Assert<FluentSchema<string, any, any[]>, GetSchema<string>>
 
 // GetSchema<'hello'> → FluentSchema<string, StringSchemaRules, [...(keyof StringSchemaRules)[]]>
-type GSStringLiteral = GetSchema<'hello'>
+type GSStringLiteral = Assert<FluentSchema<string, any, [...(keyof any)[]]>, GetSchema<'hello'>>
 
 // GetSchema<number> → FluentSchema<number, NumberSchemaRules>
 type GSNumber = Assert<FluentSchema<number, any, any[]>, GetSchema<number>>
 
 // GetSchema<42> → FluentSchema<number, NumberSchemaRules, [...(keyof NumberSchemaRules)[]]>
-type GSNumberLiteral = GetSchema<42>
+type GSNumberLiteral = Assert<FluentSchema<number, any, [...(keyof any)[]]>, GetSchema<42>>
 
 // GetSchema<bigint> → FluentSchema<bigint, NumberSchemaRules>
 type GSBigint = Assert<FluentSchema<bigint, any, any[]>, GetSchema<bigint>>
@@ -79,13 +80,19 @@ type GSRecord = Assert<
 >
 
 // GetSchema<{ foo: string }> → FluentSchema<Sanitize<{ foo: string }>>
-type GSObject = GetSchema<{ foo: string }>
+type GSObject = Assert<FluentSchema<Sanitize<{ foo: string }>>, GetSchema<{ foo: string }>>
 
 // GetSchema<{ foo?: string }> → FluentSchema<Sanitize<{ foo?: string }>>
-type GSOptionalObject = GetSchema<{ foo?: string }>
+type GSOptionalObject = Assert<
+    FluentSchema<Sanitize<{ foo?: string }>>,
+    GetSchema<{ foo?: string }>
+>
 
 // GetSchema<string | number> → FluentSchema<string | number>
 type GSUnion = Assert<FluentSchema<string | number>, GetSchema<string | number>>
+
+// GetSchema never returns never for valid inputs
+type _GSNeverCheck = Assert<never, never>
 
 // Reference all type aliases to suppress noUnusedLocals
 const _type_checks: [
@@ -104,6 +111,7 @@ const _type_checks: [
     GSObject,
     GSOptionalObject,
     GSUnion,
+    _GSNeverCheck,
 ] = null as any
 void _type_checks
 

--- a/src/validators/schema/types/index.ts
+++ b/src/validators/schema/types/index.ts
@@ -16,6 +16,8 @@ import type {
     TypeGuardFactory,
     TypeGuardFactoryType,
 } from '../helpers/optional/types.ts'
+import type { ValidationError } from '../../ValidationError.ts'
+import type { ValidationErrors } from '../../ValidationErrors.ts'
 
 export type Optionalize<T> = {
     [K in keyof T]: T[K] extends () => TypeGuard<any | any[]>
@@ -685,7 +687,13 @@ export type * from './UnionSchema.ts'
 export type * from './IntersectionSchema.ts'
 export type * from './GetSchema.ts'
 
-export type { ValidateReturn } from '../../SchemaValidator.ts'
+export type ValidateReturn<T> =
+    | T
+    | ValidationErrors<
+        | ValidationError<unknown, T>
+        | ValidationError<unknown, T[Extract<keyof T, string>], Extract<keyof T, string>, T>
+        | ValidationError
+    >
 
 export type {
     Custom,

--- a/src/validators/schema/types/index.ts
+++ b/src/validators/schema/types/index.ts
@@ -1,14 +1,16 @@
-import type Generics from '../../../Generics/index.ts'
 import type { GetTypeGuard, TypeGuard } from '../../../TypeGuards/types/index.ts'
-import type { Spread } from '../../../types/index.ts'
 import type {
     OptionalizeTypeGuard,
     TypeGuardFactory,
     TypeGuardFactoryType,
 } from '../helpers/optional/types.ts'
 
-import type { V3, BaseStruct } from './v3/index.ts'
+import type * as V1 from './v1/index.ts'
+import type * as V2 from './v2/index.ts'
+import type { V3 } from './v3/index.ts'
 
+export type { V1 }
+export type { V2 }
 export * from './v3/index.ts'
 export type { V3 } from './v3/index.ts'
 
@@ -27,7 +29,7 @@ export type GetSchemaStruct<T extends TypeGuard> = GetStruct<GetTypeGuard<T>>
 : T extends Function
 ? never
 : {
-[K in keyof T]: GetStruct<T[K]>
+    [K in keyof T]: GetStruct<T[K]>
 } */
 export type GetStruct<TFrom extends TypeGuard | TypeGuardFactory> =
     TFrom extends TypeGuard<infer T>
@@ -36,265 +38,11 @@ export type GetStruct<TFrom extends TypeGuard | TypeGuardFactory> =
           ? TypeGuardFactoryType<TFrom>
           : never
 
-export namespace V2 {
-    export type PrimitiveStruct<T = Generics.PrimitiveType> = T extends Generics.PrimitiveType
-        ? BaseStruct<'primitive', Generics.PrimitiveType>
-        : never
-    export type AnyStruct = BaseStruct<'any', any>
-    export type UndefinedStruct<T = undefined> = T extends undefined
-        ? BaseStruct<'undefined', undefined>
-        : never
-    export type NullStruct<T = null> = T extends null ? BaseStruct<'null', null> : never
-    export type BooleanStruct<T = boolean> = T extends boolean ? BaseStruct<'boolean', T> : never
-    export type NumberStruct<T = number> = T extends number ? BaseStruct<'number', T> : never
-    export type BigIntStruct<T = bigint> = T extends bigint ? BaseStruct<'bigint', T> : never
-    export type StringStruct<T = string> = T extends string ? BaseStruct<'string', T> : never
-    export type SymbolStruct<T = symbol> = T extends symbol ? BaseStruct<'symbol', symbol> : never
-
-    type UnionOrIntersectionPartialStruct<T1, T2> = {
-        types: [GenericStruct<T1>, GenericStruct<T2>]
-    }
-    type EnumPartialStruct<T> = {
-        types: (
-            | V2.UndefinedStruct<T>
-            | V2.NullStruct<T>
-            | V2.BooleanStruct<T>
-            | V2.BigIntStruct<T>
-            | V2.NumberStruct<T>
-            | V2.StringStruct<T>
-            | V2.SymbolStruct<T>
-            | BaseStruct<
-                  'undefined' | 'null' | 'boolean' | 'number' | 'bigint' | 'string' | 'symbol',
-                  T
-              >
-        )[]
-    }
-
-    export type EnumStruct<T extends Generics.PrimitiveType = any> = Spread<
-        [BaseStruct<'enum', T>, EnumPartialStruct<T>]
-    >
-
-    export type UnionStruct<T1 = unknown, T2 = unknown> = Spread<
-        [BaseStruct<'union', T1 | T2>, UnionOrIntersectionPartialStruct<T1, T2>]
-    >
-    export type IntersectionStruct<T1 = unknown, T2 = unknown> = Spread<
-        [BaseStruct<'intersection', T1 & T2>, UnionOrIntersectionPartialStruct<T1, T2>]
-    >
-
-    export type ObjectTree<T> = {
-        tree: {
-            [K in keyof T]: V2.GenericStruct<T[K]>
-        }
-    }
-    export type ObjectStruct<T> = Spread<
-        [
-            BaseStruct<'object', T>,
-            {
-                [K2 in keyof ObjectTree<T>]: V2.ObjectTree<T>[K2]
-            },
-        ]
-    >
-
-    export type ArrayEntries<U> = {
-        entries: V2.GenericStruct<U>
-    }
-
-    export type ArrayStruct<U> = Spread<
-        [
-            {
-                [K1 in keyof BaseStruct<'object', U[]>]: BaseStruct<'object', U[]>[K1]
-            },
-            {
-                [K2 in keyof ArrayEntries<U>]: ArrayEntries<U>[K2]
-            },
-        ]
-    >
-
-    export type GenericStruct<
-        T = any,
-        UnionOrIntersection extends 'union' | 'intersection' | true | false = true,
-    > =
-        | V2.Struct<T>
-        | (UnionOrIntersection extends false
-              ? never
-              : UnionOrIntersection extends 'union'
-                ? V2.UnionStruct<T, T>
-                : UnionOrIntersection extends 'intersection'
-                  ? V2.IntersectionStruct<T, T>
-                  : V2.UnionStruct<T, T> | V2.IntersectionStruct<T, T>)
-
-    export type Struct<T = any> =
-        | (T extends Generics.PrimitiveType
-              ? T extends undefined
-                  ? V2.UndefinedStruct
-                  : T extends null
-                    ? V2.NullStruct
-                    : T extends boolean
-                      ? V2.BooleanStruct<T>
-                      : T extends bigint
-                        ? V2.BigIntStruct<T>
-                        : T extends number
-                          ? V2.NumberStruct<T>
-                          : T extends string
-                            ? V2.StringStruct<T>
-                            : T extends symbol
-                              ? V2.SymbolStruct
-                              : V2.PrimitiveStruct<T> | V2.AnyStruct | V2.EnumStruct<T>
-              : never)
-        | (T extends (infer _)[]
-              ? never
-              : T extends Generics.PrimitiveType
-                ? never
-                : T extends object
-                  ? V2.ObjectStruct<T>
-                  : never)
-        | (T extends (infer U)[] ? V2.ArrayStruct<U> : never)
-
-    export type StructType =
-        | PrimitiveStruct<Generics.PrimitiveType>
-        | AnyStruct
-        | UndefinedStruct
-        | NullStruct
-        | BooleanStruct
-        | NumberStruct
-        | BigIntStruct
-        | StringStruct
-        | SymbolStruct
-        | UnionOrIntersectionPartialStruct<any, any>
-        | EnumStruct<Generics.PrimitiveType>
-        | UnionStruct<any>
-        | IntersectionStruct<any>
-}
-
-export namespace V1 {
-    export type ObjectTree<T> = {
-        tree: {
-            [K in keyof T]: Struct<
-                T[K] extends Generics.PrimitiveType ? Generics.GetPrimitiveTag<T[K]> : 'object',
-                T[K]
-            >
-        }
-    }
-    export type ObjectStruct<T> = Spread<
-        [
-            {
-                [K1 in keyof BaseStruct<'object', T>]: BaseStruct<'object', T>[K1]
-            },
-            {
-                [K2 in keyof ObjectTree<T>]: ObjectTree<T>[K2]
-            },
-        ]
-    >
-
-    export type ArrayEntries<T extends Generics.BaseTypes, U> = {
-        entries: BaseStruct<T, U> | ObjectStruct<U> | ArrayStruct<T, U>
-    }
-    export type ArrayStruct<T extends Generics.BaseTypes, U> = Spread<
-        [
-            {
-                [K1 in keyof BaseStruct<'object', U>]: BaseStruct<'object', U>[K1]
-            },
-            {
-                [K2 in keyof ArrayEntries<T, U>]: ArrayEntries<T, U>[K2]
-            },
-        ]
-    >
-
-    export type Struct<T extends Generics.BaseTypes, U> = U extends Generics.PrimitiveType
-        ? T extends 'enum'
-            ? BaseStruct<'enum', U>
-            : T extends 'primitive'
-              ? BaseStruct<'primitive', Generics.PrimitiveType>
-              : T extends 'union'
-                ? Spread<
-                      [
-                          BaseStruct<'union', U>,
-                          {
-                              tree: Struct<
-                                  U extends Generics.PrimitiveType
-                                      ? Generics.GetPrimitiveTag<U>
-                                      : 'object',
-                                  U
-                              >[]
-                          },
-                      ]
-                  >
-                : T extends 'intersection'
-                  ? Spread<
-                        [
-                            BaseStruct<'intersection', U>,
-                            {
-                                tree: Struct<
-                                    U extends Generics.PrimitiveType
-                                        ? Generics.GetPrimitiveTag<U>
-                                        : 'object',
-                                    U
-                                >[]
-                            },
-                        ]
-                    >
-                  : T extends 'any'
-                    ? BaseStruct<'any', any>
-                    : T extends 'undefined'
-                      ? BaseStruct<'undefined', undefined>
-                      : T extends 'null'
-                        ? BaseStruct<'null', null>
-                        : U extends boolean
-                          ? BaseStruct<'boolean', boolean>
-                          : BaseStruct<T, U> & {
-                                tree?: undefined
-                            }
-        : U extends Array<infer V>
-          ? Spread<
-                [
-                    BaseStruct<'object', U>,
-                    {
-                        entries: Struct<
-                            V extends Generics.PrimitiveType
-                                ? Generics.GetPrimitiveTag<V>
-                                : 'object',
-                            V
-                        >
-                    },
-                ]
-            >
-          : // biome-ignore lint/complexity/noBannedTypes: Function used in conditional type for function detection
-            U extends Function
-            ? BaseStruct<'function', U>
-            : U extends object
-              ? V1.ObjectStruct<U>
-              : never
-}
-
-export type PrimitiveStruct<T extends Generics.PrimitiveType = Generics.PrimitiveType> = Prettify<
-    Omit<V3.PrimitiveStruct, 'schema'> & { schema: TypeGuard<T> }
->
-export type AnyStruct = V3.AnyStruct
-export type UndefinedStruct = V3.UndefinedStruct
-export type NullStruct = V3.NullStruct
-export type BooleanStruct = V3.BooleanStruct
-export type BigIntStruct = V3.BigIntStruct
-export type NumberStruct = V3.NumberStruct
-export type StringStruct = V3.StringStruct
-export type SymbolStruct = V3.SymbolStruct
-export type EnumStruct<T extends Generics.PrimitiveType> = V3.EnumStruct<T>
-
-export type UnionStruct<Types extends any[]> = V3.UnionStruct<Types>
-export type IntersectionStruct<Types extends any[]> = V3.IntersectionStruct<Types>
-export type TupleStruct<Types extends readonly any[]> = V3.TupleStruct<Types>
-export type ArrayStruct<U> = V3.ArrayStruct<U>
-export type ObjectStruct<T extends {}> = V3.ObjectStruct<T>
-export type RecordStruct<K extends keyof any = string, T = any> = V3.RecordStruct<K, T>
-export type ClassInstanceStruct<T extends {}, ClassNameStr = string> = V3.ClassInstanceStruct<
-    T,
-    ClassNameStr
->
-export type CustomStruct<T> = V3.CustomStruct<T>
-
 export type GenericStruct<
     T = any,
     UnionOrIntersection extends 'union' | 'intersection' | true | false = true,
 > = V3.GenericStruct<T, UnionOrIntersection>
+export type ObjectStruct<T extends {}> = V3.ObjectStruct<T>
 export type Struct<T = any> = V3.Struct<T>
 export type StructType = V3.StructType
 

--- a/src/validators/schema/types/index.ts
+++ b/src/validators/schema/types/index.ts
@@ -690,10 +690,10 @@ export type * from './GetSchema.ts'
 export type ValidateReturn<T> =
     | T
     | ValidationErrors<
-        | ValidationError<unknown, T>
-        | ValidationError<unknown, T[Extract<keyof T, string>], Extract<keyof T, string>, T>
-        | ValidationError
-    >
+          | ValidationError<unknown, T>
+          | ValidationError<unknown, T[Extract<keyof T, string>], Extract<keyof T, string>, T>
+          | ValidationError
+      >
 
 export type {
     Custom,

--- a/src/validators/schema/types/index.ts
+++ b/src/validators/schema/types/index.ts
@@ -671,3 +671,27 @@ export type GenericStruct<
 > = V3.GenericStruct<T, UnionOrIntersection>
 export type Struct<T = any> = V3.Struct<T>
 export type StructType = V3.StructType
+
+export type * from './BooleanSchema.ts'
+export type * from './NullSchema.ts'
+export type * from './UndefinedSchema.ts'
+export type * from './SymbolSchema.ts'
+export type * from './AnySchema.ts'
+export type * from './PrimitiveSchema.ts'
+export type * from './EnumSchema.ts'
+export type * from './ObjectSchema.ts'
+export type * from './TupleSchema.ts'
+export type * from './UnionSchema.ts'
+export type * from './IntersectionSchema.ts'
+export type * from './GetSchema.ts'
+
+export type { ValidateReturn } from '../../SchemaValidator.ts'
+
+export type {
+    Custom,
+    CustomFactory,
+    Rule,
+    RuleStruct,
+    CreateRuleArgs,
+    CUSTOM_RULE_BRAND,
+} from '../../rules/types/index.ts'

--- a/src/validators/schema/types/index.ts
+++ b/src/validators/schema/types/index.ts
@@ -1,9 +1,5 @@
-import type { GetTypeGuard, TypeGuard } from '../../../TypeGuards/types/index.ts'
-import type {
-    OptionalizeTypeGuard,
-    TypeGuardFactory,
-    TypeGuardFactoryType,
-} from '../helpers/optional/types.ts'
+import type { TypeGuard } from '../../../TypeGuards/types/index.ts'
+import type { TypeGuardFactory, TypeGuardFactoryType } from '../helpers/optional/types.ts'
 
 import type * as V1 from './v1/index.ts'
 import type * as V2 from './v2/index.ts'
@@ -11,16 +7,20 @@ import type { V3 } from './v3/index.ts'
 
 export type { V1 }
 export type { V2 }
-export * from './v3/index.ts'
 export type { V3 } from './v3/index.ts'
 
-export type Optionalize<T> = {
-    [K in keyof T]: T[K] extends () => TypeGuard<any | any[]>
-        ? (...args: Parameters<T[K]>) => OptionalizeTypeGuard<ReturnType<T[K]>>
-        : T[K]
-}
-
-export type GetSchemaStruct<T extends TypeGuard> = GetStruct<GetTypeGuard<T>>
+// ─── Public V3 flat exports (explicit allowlist — no wildcard re-export) ───
+// The wildcard `export * from './v3/index.ts'` leaked ~25 internal composition
+// types (RequiredPartialStruct, OptionalPartialStruct, WithRulesStruct, MapToStructs,
+// ExactExtends, IsExactExtension, ObjectTree, ClassInstanceRef, ArrayEntries,
+// RecordMetadata, TupleMetadata, TupleToTypeGuardMap, TupleToStructMap,
+// AsPrimitiveStruct, FromUnionStruct, FromIntersectionStruct, FromRecordStruct,
+// FromClassInstanceStruct, FromTupleStruct, etc.) that are only meaningful as V3
+// namespace internals.  Consumers should access them via `V3.<Name>` if needed.
+// Only the 4 top-level flat exports are listed here:
+export type { BaseStruct } from './v3/index.ts'
+export type { TUnion, TIntersection } from './v3/index.ts'
+export type { TypeGuardTupleUnwrap } from './v3/index.ts'
 
 export type GetStruct<TFrom extends TypeGuard | TypeGuardFactory> =
     TFrom extends TypeGuard<infer T>
@@ -29,6 +29,7 @@ export type GetStruct<TFrom extends TypeGuard | TypeGuardFactory> =
           ? TypeGuardFactoryType<TFrom>
           : never
 
+// Top-level V3 aliases — backward compat with consumers importing bare names
 export type GenericStruct<
     T = any,
     UnionOrIntersection extends 'union' | 'intersection' | true | false = true,
@@ -59,11 +60,4 @@ export type * from './RecordSchema.ts'
 
 export type { ValidateReturn } from '../../types/ValidateReturn.ts'
 
-export type {
-    Custom,
-    CustomFactory,
-    Rule,
-    RuleStruct,
-    CreateRuleArgs,
-    CUSTOM_RULE_BRAND,
-} from '../../rules/types/index.ts'
+export type { Custom, CustomFactory, Rule, CreateRuleArgs } from '../../rules/types/index.ts'

--- a/src/validators/schema/types/index.ts
+++ b/src/validators/schema/types/index.ts
@@ -22,15 +22,6 @@ export type Optionalize<T> = {
 
 export type GetSchemaStruct<T extends TypeGuard> = GetStruct<GetTypeGuard<T>>
 
-/* export type GetStruct<T> = T extends Array<infer Inner>
-? GetStruct<Inner>[]
-: T extends Generics.PrimitiveType
-? Struct<Generics.GetPrimitiveTag<T, T>
-: T extends Function
-? never
-: {
-    [K in keyof T]: GetStruct<T[K]>
-} */
 export type GetStruct<TFrom extends TypeGuard | TypeGuardFactory> =
     TFrom extends TypeGuard<infer T>
         ? V3.Struct<T>

--- a/src/validators/schema/types/index.ts
+++ b/src/validators/schema/types/index.ts
@@ -1,23 +1,16 @@
 import type Generics from '../../../Generics/index.ts'
-import type {
-    ConstructorSignature,
-    GetTypeGuard,
-    TypeGuard,
-} from '../../../TypeGuards/types/index.ts'
+import type { GetTypeGuard, TypeGuard } from '../../../TypeGuards/types/index.ts'
 import type { Spread } from '../../../types/index.ts'
-import type { ArrayRule } from '../../rules/Array/index.ts'
-import type { NumberRule } from '../../rules/Number/index.ts'
-import type { RecordRule } from '../../rules/Record/index.ts'
-import type { StringRule } from '../../rules/String/index.ts'
-import type { StandardSchemaV1 } from '../../standard-schema/types.ts'
-import type { All as AllRules, Custom as CustomRule, RuleStruct } from '../../rules/types/index.ts'
 import type {
     OptionalizeTypeGuard,
     TypeGuardFactory,
     TypeGuardFactoryType,
 } from '../helpers/optional/types.ts'
-import type { ValidationError } from '../../ValidationError.ts'
-import type { ValidationErrors } from '../../ValidationErrors.ts'
+
+import type { V3, BaseStruct } from './v3/index.ts'
+
+export * from './v3/index.ts'
+export type { V3 } from './v3/index.ts'
 
 export type Optionalize<T> = {
     [K in keyof T]: T[K] extends () => TypeGuard<any | any[]>
@@ -28,389 +21,20 @@ export type Optionalize<T> = {
 export type GetSchemaStruct<T extends TypeGuard> = GetStruct<GetTypeGuard<T>>
 
 /* export type GetStruct<T> = T extends Array<infer Inner>
-    ? GetStruct<Inner>[]
-    : T extends Generics.PrimitiveType
-    ? Struct<Generics.GetPrimitiveTag<T, T>
-    : T extends Function
-    ? never
-    : {
-          [K in keyof T]: GetStruct<T[K]>
-      } */
+? GetStruct<Inner>[]
+: T extends Generics.PrimitiveType
+? Struct<Generics.GetPrimitiveTag<T, T>
+: T extends Function
+? never
+: {
+[K in keyof T]: GetStruct<T[K]>
+} */
 export type GetStruct<TFrom extends TypeGuard | TypeGuardFactory> =
     TFrom extends TypeGuard<infer T>
-        ? Struct<T>
+        ? V3.Struct<T>
         : TFrom extends TypeGuardFactory
           ? TypeGuardFactoryType<TFrom>
           : never
-
-export type BaseStruct<T extends Generics.BaseTypes | 'custom', U> = {
-    type: T
-    schema: TypeGuard<U>
-    optional: boolean
-}
-
-export namespace V3 {
-    export type RequiredPartialStruct = {
-        optional: false
-    }
-    export type OptionalPartialStruct = {
-        optional: true
-    }
-
-    export type RequirefyStruct<S extends Struct> = Omit<S, 'optional'> & RequiredPartialStruct
-    export type OptionalizeStruct<S extends Struct> = Omit<S, 'optional'> & OptionalPartialStruct
-
-    export type PrimitiveStruct<
-        Rules extends CustomRule<any[], string, Generics.PrimitiveType> = CustomRule<
-            any[],
-            string,
-            Generics.PrimitiveType
-        >,
-    > = BaseStruct<'primitive', Generics.PrimitiveType> & WithRulesStruct<Rules>
-    export type AnyStruct<
-        Rules extends CustomRule<any[], string, any> = CustomRule<any[], string, any>,
-    > = BaseStruct<'any', any> & WithRulesStruct<Rules>
-    export type UndefinedStruct<
-        Rules extends CustomRule<any[], string, undefined> = CustomRule<any[], string, undefined>,
-    > = BaseStruct<'undefined', undefined> & WithRulesStruct<Rules>
-    export type NullStruct<
-        Rules extends CustomRule<any[], string, null> = CustomRule<any[], string, null>,
-    > = BaseStruct<'null', null> & WithRulesStruct<Rules>
-    export type BooleanStruct<
-        Rules extends CustomRule<any[], string, boolean> = CustomRule<any[], string, boolean>,
-    > = BaseStruct<'boolean', boolean> & WithRulesStruct<Rules>
-    export type NumberStruct<
-        Rules extends CustomRule<any[], string, number> = CustomRule<any[], string, number>,
-    > = BaseStruct<'number', number> & WithRulesStruct<NumberRule | Rules>
-    export type BigIntStruct<
-        Rules extends CustomRule<any[], string, bigint> = CustomRule<any[], string, bigint>,
-    > = BaseStruct<'bigint', bigint> & WithRulesStruct<NumberRule | Rules>
-    export type StringStruct<
-        Rules extends CustomRule<any[], string, string> = CustomRule<any[], string, string>,
-    > = BaseStruct<'string', string> & WithRulesStruct<StringRule | Rules>
-    export type SymbolStruct<
-        Rules extends CustomRule<any[], string, symbol> = CustomRule<any[], string, symbol>,
-    > = BaseStruct<'symbol', symbol> & WithRulesStruct<Rules>
-
-    export type WithRulesStruct<Rule extends AllRules<any[], string, any>> = {
-        rules: RuleStruct<Rule>[]
-    }
-
-    export type MapToStructs<Types extends any[]> = Types extends []
-        ? []
-        : Types extends [infer T0, ...infer TRest]
-          ? [GenericStruct<T0, true> | CustomStruct<T0> | StructType, ...MapToStructs<TRest>]
-          : (GenericStruct<any, true> | CustomStruct<any> | StructType)[]
-
-    export type TUnion<Types extends any[]> = Types extends []
-        ? never
-        : Types extends [infer T0, ...infer TRest]
-          ? TRest extends []
-              ? T0
-              : T0 | TUnion<TRest>
-          : any
-    export type TIntersection<Types extends any[]> = Types extends []
-        ? never
-        : Types extends [infer T0, ...infer TRest]
-          ? TRest extends []
-              ? T0
-              : T0 & TIntersection<TRest>
-          : any
-
-    export type ExactExtends<TSource, TCompare, TValueIfTrue = TSource, TValueIfFalse = never> =
-        Exclude<TSource, TCompare> extends never ? TValueIfTrue : TValueIfFalse
-    export type IsExactExtension<TSource, TCompare> = ExactExtends<TSource, TCompare, true, false>
-
-    type UnionOrIntersectionPartialStruct<Types extends any[]> = {
-        types: MapToStructs<Types>
-    }
-
-    type EnumPartialStruct<T extends Generics.PrimitiveType = any> = {
-        // types: (AsPrimitiveStruct<T> & RequiredPartialStruct)[]
-
-        types: ((
-            | StringStruct
-            | NumberStruct
-            | BigIntStruct
-            | BooleanStruct
-            | SymbolStruct
-            | NullStruct
-            | UndefinedStruct
-        ) &
-            // ({ type: 'string' } | { type: 'number' } | { type: 'symbol' }) &
-
-            Generics.WrapInObject<Generics.GetPrimitiveTag<T>, 'type'> &
-            RequiredPartialStruct)[]
-
-        // types: (Exclude<
-        //     | StringStruct
-        //     | NumberStruct
-        //     | BigIntStruct
-        //     | BooleanStruct
-        //     | SymbolStruct
-        //     | NullStruct
-        //     | UndefinedStruct,
-        //     AsPrimitiveStruct<T>
-        // > &
-        //     RequiredPartialStruct)[]
-
-        // types: (
-        //     | UndefinedStruct
-        //     | NullStruct
-        //     | BooleanStruct
-        //     | BigIntStruct
-        //     | NumberStruct
-        //     | StringStruct
-        //     | SymbolStruct
-        // )[]
-    }
-
-    export type EnumStruct<
-        T extends Generics.PrimitiveType = any,
-        Rules extends CustomRule<any[], string, Generics.PrimitiveType> = CustomRule<
-            any[],
-            string,
-            Generics.PrimitiveType
-        >,
-    > = BaseStruct<'enum', T> & EnumPartialStruct<T> & WithRulesStruct<Rules>
-
-    export type UnionStruct<
-        Types extends any[],
-        Rules extends CustomRule<any[], string, any> = CustomRule<any[], string, any>,
-    > = BaseStruct<'union', TUnion<Types>> &
-        UnionOrIntersectionPartialStruct<Types> &
-        WithRulesStruct<Rules>
-
-    export type IntersectionStruct<
-        Types extends any[],
-        Rules extends CustomRule<any[], string, any> = CustomRule<any[], string, any>,
-    > = BaseStruct<'intersection', TIntersection<Types>> &
-        UnionOrIntersectionPartialStruct<Types> &
-        WithRulesStruct<Rules>
-
-    export type ObjectTree<T extends {}> = {
-        tree: {
-            [K in keyof T]: V3.GenericStruct<T[K]> | V3.StructType
-        }
-    }
-
-    export type ObjectStruct<
-        T extends {},
-        Rules extends CustomRule<any[], string, T> = CustomRule<any[], string, T>,
-    > = BaseStruct<'object', T> & ObjectTree<T> & WithRulesStruct<Rules>
-
-    export type ClassInstanceRef<T extends {}, ClassNameStr = string> = {
-        constructor: ConstructorSignature<T>
-        className: ClassNameStr
-    }
-
-    export type ClassInstanceStruct<
-        T extends {},
-        ClassNameStr = string,
-        Rules extends CustomRule<any[], string, T> = CustomRule<any[], string, T>,
-    > = BaseStruct<'object', T> &
-        // biome-ignore lint/complexity/noBannedTypes: {} as generic constraint for non-nullish is idiomatic TS
-        ObjectTree<{}> &
-        ClassInstanceRef<T, ClassNameStr> &
-        WithRulesStruct<Rules>
-
-    export type ArrayEntries<U> = {
-        entries: V3.GenericStruct<U>
-    }
-
-    export type ArrayStruct<
-        U,
-        Rules extends CustomRule<any[], string, U[]> = CustomRule<any[], string, U[]>,
-    > = BaseStruct<'object', U[]> & ArrayEntries<U> & WithRulesStruct<ArrayRule | Rules>
-
-    export type RecordMetadata<T extends {}> = {
-        keyMetadata:
-            | V3.StringStruct
-            | V3.NumberStruct
-            | V3.SymbolStruct
-            | V3.EnumStruct<PropertyKey>
-            | (V3.CustomStruct<string> & { kind: 'string' })
-        valueMetadata: V3.GenericStruct<T[keyof T]> | V3.StructType
-    }
-
-    export type RecordStruct<
-        K extends PropertyKey = string,
-        T = any,
-        Rules extends CustomRule<any[], string, Record<K, T>> = CustomRule<
-            any[],
-            string,
-            Record<K, T>
-        >,
-    > = BaseStruct<'record', Record<K, T>> &
-        RecordMetadata<Record<K, T>> &
-        WithRulesStruct<RecordRule | Rules>
-
-    export type TupleMetadata<T extends readonly [...any]> = {
-        elements: TupleToStructMap<T>
-    }
-
-    export type TupleToTypeGuardMap<T extends readonly [...any]> = T extends readonly [
-        infer T0,
-        ...infer TRest,
-    ]
-        ? readonly [TypeGuard<T0>, ...TupleToTypeGuardMap<TRest>]
-        : T
-
-    export type TupleToStructMap<T extends readonly [...any]> = T extends readonly [
-        infer T0,
-        ...infer TRest,
-    ]
-        ? readonly [V3.GenericStruct<T0>, ...TupleToStructMap<TRest>]
-        : T
-
-    export type TypeGuardTupleUnwrap<T extends readonly [...any]> = T extends readonly [
-        infer T0,
-        ...infer TRest,
-    ]
-        ? T0 extends TypeGuard<infer U>
-            ? [U, ...TypeGuardTupleUnwrap<TRest>]
-            : T0 extends StandardSchemaV1<infer U, any>
-              ? [U, ...TypeGuardTupleUnwrap<TRest>]
-              : [T0, ...TypeGuardTupleUnwrap<TRest>]
-        : T
-
-    export type TupleStruct<
-        T extends readonly [...any],
-        Rules extends CustomRule<any[], string, T> = CustomRule<any[], string, T>,
-    > = BaseStruct<'tuple', T> & TupleMetadata<T> & WithRulesStruct<Rules>
-
-    export type CustomStruct<
-        T,
-        Rules extends CustomRule<any[], string, T> = CustomRule<any[], string, T>,
-    > = Prettify<
-        BaseStruct<'custom', T> & {
-            /** kind of the custom struct's value mapped */
-            kind?: string
-            /** context metadata for the custom struct */
-            context?: Record<string, any> | null
-        } & WithRulesStruct<Rules>
-    >
-
-    export type GenericStruct<
-        T = any,
-        UnionOrIntersection extends 'union' | 'intersection' | true | false = true,
-        Rules extends CustomRule<any[], string, any> = CustomRule<any[], string, any>,
-        // biome-ignore lint/complexity/noBannedTypes: Function used in conditional type for type-level dispatch
-    > = T extends Function
-        ? AnyStruct<Rules> & { schema: TypeGuard<T> }
-        :
-              | Struct<T, Rules>
-              | CustomStruct<T, Rules>
-              | (UnionOrIntersection extends false
-                    ? never
-                    : UnionOrIntersection extends 'union'
-                      ? T extends any[]
-                          ? UnionStruct<T, Rules>
-                          : never
-                      : UnionOrIntersection extends 'intersection'
-                        ? T extends any[]
-                            ? IntersectionStruct<T, Rules>
-                            : never
-                        : T extends any[]
-                          ? UnionStruct<T, Rules> | IntersectionStruct<T, Rules>
-                          : never)
-
-    export type AsPrimitiveStruct<
-        T extends Generics.PrimitiveType,
-        // MatchPartialPrimitiveSet extends true | false = false,
-        Rules extends CustomRule<any[], string, Generics.PrimitiveType> = CustomRule<
-            any[],
-            string,
-            Generics.PrimitiveType
-        >,
-    > =
-        // MatchPartialPrimitiveSet extends false?
-        IsExactExtension<Generics.PrimitiveType, T> extends true
-            ? PrimitiveStruct<Rules>
-            : IsExactExtension<T, undefined> extends true
-              ? UndefinedStruct<Rules>
-              : IsExactExtension<T, null> extends true
-                ? NullStruct<Rules>
-                : IsExactExtension<T, boolean> extends true
-                  ? BooleanStruct<Rules>
-                  : IsExactExtension<T, bigint> extends true
-                    ? BigIntStruct<Rules>
-                    : IsExactExtension<T, number> extends true
-                      ? NumberStruct<Rules>
-                      : IsExactExtension<T, string> extends true
-                        ? StringStruct<Rules>
-                        : IsExactExtension<T, symbol> extends true
-                          ? SymbolStruct<Rules>
-                          : never
-
-    export type Struct<
-        T = any,
-        Rules extends CustomRule<any[], string, any> = CustomRule<any[], string, any>,
-    > = T extends Generics.PrimitiveType
-        ? EnumStruct<T, Rules> | IsExactExtension<T, undefined> extends true
-            ? UndefinedStruct<Rules>
-            : IsExactExtension<T, null> extends true
-              ? NullStruct<Rules>
-              : IsExactExtension<T, boolean> extends true
-                ? BooleanStruct<Rules>
-                : IsExactExtension<T, bigint> extends true
-                  ? BigIntStruct<Rules>
-                  : IsExactExtension<T, number> extends true
-                    ? NumberStruct<Rules>
-                    : IsExactExtension<T, string> extends true
-                      ? StringStruct<Rules>
-                      : IsExactExtension<T, symbol> extends true
-                        ? SymbolStruct<Rules>
-                        : never
-        : T extends readonly [...any]
-          ? TupleStruct<T, Rules>
-          : T extends (infer U)[]
-            ? ArrayStruct<U, Rules>
-            : // biome-ignore lint/complexity/noBannedTypes: {} used in conditional type for object detection
-              T extends {}
-              ?
-                    | ObjectStruct<T, Rules>
-                    | RecordStruct<keyof T, T[keyof T], Rules>
-                    | ClassInstanceStruct<T, Rules>
-              : never
-
-    export type StructType<
-        Rules extends CustomRule<any[], string, any> = CustomRule<any[], string, any>,
-    > =
-        | PrimitiveStruct<Rules>
-        | AnyStruct<Rules>
-        | UndefinedStruct<Rules>
-        | NullStruct<Rules>
-        | BooleanStruct<Rules>
-        | NumberStruct<Rules>
-        | BigIntStruct<Rules>
-        | StringStruct<Rules>
-        | SymbolStruct<Rules>
-        | EnumStruct<Generics.PrimitiveType, Rules>
-        | UnionStruct<any[], Rules>
-        | IntersectionStruct<any[], Rules>
-        | ObjectStruct<any, Rules>
-        | ArrayStruct<any, Rules>
-        | RecordStruct<string, any, Rules>
-        | ClassInstanceStruct<any, Rules>
-        | TupleStruct<any[], Rules>
-        | CustomStruct<any, Rules>
-
-    export type FromStruct<T extends Struct<any>> = T extends Struct<infer U> ? U : never
-    export type FromUnionStruct<T extends UnionStruct<any>> =
-        T extends UnionStruct<infer U> ? TUnion<U> : never
-    export type FromIntersectionStruct<T extends IntersectionStruct<any>> =
-        T extends IntersectionStruct<infer U> ? TIntersection<U> : never
-
-    export type FromRecordStruct<T extends RecordStruct<any, any>> =
-        T extends RecordStruct<infer K, infer T> ? Record<K, T> : never
-
-    export type FromClassInstanceStruct<T extends ClassInstanceStruct<any>> =
-        T extends ClassInstanceStruct<infer U> ? U : never
-
-    export type FromTupleStruct<T extends TupleStruct<any>> =
-        T extends TupleStruct<infer U> ? U : never
-}
 
 export namespace V2 {
     export type PrimitiveStruct<T = Generics.PrimitiveType> = T extends Generics.PrimitiveType
@@ -686,14 +310,15 @@ export type * from './TupleSchema.ts'
 export type * from './UnionSchema.ts'
 export type * from './IntersectionSchema.ts'
 export type * from './GetSchema.ts'
+export type * from './FluentSchema.ts'
+export type * from './FluentOptionalSchema.ts'
+export type * from './StringSchema.ts'
+export type * from './NumberSchema.ts'
+export type * from './BigIntSchema.ts'
+export type * from './ArraySchema.ts'
+export type * from './RecordSchema.ts'
 
-export type ValidateReturn<T> =
-    | T
-    | ValidationErrors<
-          | ValidationError<unknown, T>
-          | ValidationError<unknown, T[Extract<keyof T, string>], Extract<keyof T, string>, T>
-          | ValidationError
-      >
+export type { ValidateReturn } from '../../types/ValidateReturn.ts'
 
 export type {
     Custom,

--- a/src/validators/schema/types/v1/index.ts
+++ b/src/validators/schema/types/v1/index.ts
@@ -119,21 +119,3 @@ export type Struct<T extends BaseTypes, U> = U extends Generics.PrimitiveType
         : U extends object
           ? ObjectStruct<U>
           : never
-
-export type PrimitiveStruct<T extends Generics.PrimitiveType = Generics.PrimitiveType> =
-    T extends Generics.PrimitiveType ? BaseStruct<'primitive', Generics.PrimitiveType> : never
-export type AnyStruct = BaseStruct<'any', any>
-export type UndefinedStruct<T = undefined> = T extends undefined
-    ? BaseStruct<'undefined', undefined>
-    : never
-export type NullStruct<T = null> = T extends null ? BaseStruct<'null', null> : never
-export type BooleanStruct<T extends boolean = boolean> = T extends boolean
-    ? BaseStruct<'boolean', T>
-    : never
-export type NumberStruct<T extends number = number> = T extends number
-    ? BaseStruct<'number', T>
-    : never
-export type StringStruct<T extends string = string> = T extends string
-    ? BaseStruct<'string', T>
-    : never
-export type SymbolStruct = BaseStruct<'symbol', symbol>

--- a/src/validators/schema/types/v1/index.ts
+++ b/src/validators/schema/types/v1/index.ts
@@ -1,0 +1,139 @@
+import type Generics from '../../../../Generics/index.ts'
+import type { TypeGuard } from '../../../../TypeGuards/types/index.ts'
+import type { Spread } from '../../../../types/index.ts'
+
+type BaseTypes =
+    | 'string'
+    | 'number'
+    | 'boolean'
+    | 'symbol'
+    | 'null'
+    | 'undefined'
+    | 'bigint'
+    | 'object'
+    | 'function'
+    | 'enum'
+    | 'primitive'
+    | 'union'
+    | 'intersection'
+    | 'any'
+
+type BaseStruct<T extends BaseTypes, U> = {
+    type: T
+    schema: TypeGuard<U>
+    optional: boolean
+}
+
+export type ObjectTree<T> = {
+    tree: {
+        [K in keyof T]: Struct<
+            T[K] extends Generics.PrimitiveType ? Generics.GetPrimitiveTag<T[K]> : 'object',
+            T[K]
+        >
+    }
+}
+export type ObjectStruct<T> = Spread<
+    [
+        {
+            [K1 in keyof BaseStruct<'object', T>]: BaseStruct<'object', T>[K1]
+        },
+        {
+            [K2 in keyof ObjectTree<T>]: ObjectTree<T>[K2]
+        },
+    ]
+>
+
+export type ArrayEntries<T extends BaseTypes, U> = {
+    entries: BaseStruct<T, U> | ObjectStruct<U> | ArrayStruct<T, U>
+}
+export type ArrayStruct<T extends BaseTypes, U> = Spread<
+    [
+        {
+            [K1 in keyof BaseStruct<'object', U>]: BaseStruct<'object', U>[K1]
+        },
+        {
+            [K2 in keyof ArrayEntries<T, U>]: ArrayEntries<T, U>[K2]
+        },
+    ]
+>
+
+export type Struct<T extends BaseTypes, U> = U extends Generics.PrimitiveType
+    ? T extends 'enum'
+        ? BaseStruct<'enum', U>
+        : T extends 'primitive'
+          ? BaseStruct<'primitive', Generics.PrimitiveType>
+          : T extends 'union'
+            ? Spread<
+                  [
+                      BaseStruct<'union', U>,
+                      {
+                          tree: Struct<
+                              U extends Generics.PrimitiveType
+                                  ? Generics.GetPrimitiveTag<U>
+                                  : 'object',
+                              U
+                          >[]
+                      },
+                  ]
+              >
+            : T extends 'intersection'
+              ? Spread<
+                    [
+                        BaseStruct<'intersection', U>,
+                        {
+                            tree: Struct<
+                                U extends Generics.PrimitiveType
+                                    ? Generics.GetPrimitiveTag<U>
+                                    : 'object',
+                                U
+                            >[]
+                        },
+                    ]
+                >
+              : T extends 'any'
+                ? BaseStruct<'any', any>
+                : T extends 'undefined'
+                  ? BaseStruct<'undefined', undefined>
+                  : T extends 'null'
+                    ? BaseStruct<'null', null>
+                    : U extends boolean
+                      ? BaseStruct<'boolean', boolean>
+                      : BaseStruct<T, U> & {
+                            tree?: undefined
+                        }
+    : U extends Array<infer V>
+      ? Spread<
+            [
+                BaseStruct<'object', U>,
+                {
+                    entries: Struct<
+                        V extends Generics.PrimitiveType ? Generics.GetPrimitiveTag<V> : 'object',
+                        V
+                    >
+                },
+            ]
+        >
+      : // biome-ignore lint/complexity/noBannedTypes: Function used in conditional type for function detection
+        U extends Function
+        ? BaseStruct<'function', U>
+        : U extends object
+          ? ObjectStruct<U>
+          : never
+
+export type PrimitiveStruct<T extends Generics.PrimitiveType = Generics.PrimitiveType> =
+    T extends Generics.PrimitiveType ? BaseStruct<'primitive', Generics.PrimitiveType> : never
+export type AnyStruct = BaseStruct<'any', any>
+export type UndefinedStruct<T = undefined> = T extends undefined
+    ? BaseStruct<'undefined', undefined>
+    : never
+export type NullStruct<T = null> = T extends null ? BaseStruct<'null', null> : never
+export type BooleanStruct<T extends boolean = boolean> = T extends boolean
+    ? BaseStruct<'boolean', T>
+    : never
+export type NumberStruct<T extends number = number> = T extends number
+    ? BaseStruct<'number', T>
+    : never
+export type StringStruct<T extends string = string> = T extends string
+    ? BaseStruct<'string', T>
+    : never
+export type SymbolStruct = BaseStruct<'symbol', symbol>

--- a/src/validators/schema/types/v2/index.ts
+++ b/src/validators/schema/types/v2/index.ts
@@ -1,0 +1,153 @@
+import type Generics from '../../../../Generics/index.ts'
+import type { TypeGuard } from '../../../../TypeGuards/types/index.ts'
+import type { Spread } from '../../../../types/index.ts'
+
+type BaseTypes =
+    | 'string'
+    | 'number'
+    | 'boolean'
+    | 'symbol'
+    | 'null'
+    | 'undefined'
+    | 'bigint'
+    | 'object'
+    | 'function'
+    | 'enum'
+    | 'primitive'
+    | 'union'
+    | 'intersection'
+    | 'any'
+
+type BaseStruct<T extends BaseTypes, U> = {
+    type: T
+    schema: TypeGuard<U>
+    optional: boolean
+}
+
+export type PrimitiveStruct<T = Generics.PrimitiveType> = T extends Generics.PrimitiveType
+    ? BaseStruct<'primitive', Generics.PrimitiveType>
+    : never
+export type AnyStruct = BaseStruct<'any', any>
+export type UndefinedStruct<T = undefined> = T extends undefined
+    ? BaseStruct<'undefined', undefined>
+    : never
+export type NullStruct<T = null> = T extends null ? BaseStruct<'null', null> : never
+export type BooleanStruct<T = boolean> = T extends boolean ? BaseStruct<'boolean', T> : never
+export type NumberStruct<T = number> = T extends number ? BaseStruct<'number', T> : never
+export type BigIntStruct<T = bigint> = T extends bigint ? BaseStruct<'bigint', T> : never
+export type StringStruct<T = string> = T extends string ? BaseStruct<'string', T> : never
+export type SymbolStruct<T = symbol> = T extends symbol ? BaseStruct<'symbol', symbol> : never
+
+type UnionOrIntersectionPartialStruct<T1, T2> = {
+    types: [GenericStruct<T1>, GenericStruct<T2>]
+}
+type EnumPartialStruct<T> = {
+    types: (
+        | UndefinedStruct<T>
+        | NullStruct<T>
+        | BooleanStruct<T>
+        | BigIntStruct<T>
+        | NumberStruct<T>
+        | StringStruct<T>
+        | SymbolStruct<T>
+        | BaseStruct<
+              'undefined' | 'null' | 'boolean' | 'number' | 'bigint' | 'string' | 'symbol',
+              T
+          >
+    )[]
+}
+
+export type EnumStruct<T extends Generics.PrimitiveType = any> = Spread<
+    [BaseStruct<'enum', T>, EnumPartialStruct<T>]
+>
+
+export type UnionStruct<T1 = unknown, T2 = unknown> = Spread<
+    [BaseStruct<'union', T1 | T2>, UnionOrIntersectionPartialStruct<T1, T2>]
+>
+export type IntersectionStruct<T1 = unknown, T2 = unknown> = Spread<
+    [BaseStruct<'intersection', T1 & T2>, UnionOrIntersectionPartialStruct<T1, T2>]
+>
+
+export type ObjectTree<T> = {
+    tree: {
+        [K in keyof T]: GenericStruct<T[K]>
+    }
+}
+export type ObjectStruct<T> = Spread<
+    [
+        BaseStruct<'object', T>,
+        {
+            [K2 in keyof ObjectTree<T>]: ObjectTree<T>[K2]
+        },
+    ]
+>
+
+export type ArrayEntries<U> = {
+    entries: GenericStruct<U>
+}
+
+export type ArrayStruct<U> = Spread<
+    [
+        {
+            [K1 in keyof BaseStruct<'object', U[]>]: BaseStruct<'object', U[]>[K1]
+        },
+        {
+            [K2 in keyof ArrayEntries<U>]: ArrayEntries<U>[K2]
+        },
+    ]
+>
+
+export type GenericStruct<
+    T = any,
+    UnionOrIntersection extends 'union' | 'intersection' | true | false = true,
+> =
+    | Struct<T>
+    | (UnionOrIntersection extends false
+          ? never
+          : UnionOrIntersection extends 'union'
+            ? UnionStruct<T, T>
+            : UnionOrIntersection extends 'intersection'
+              ? IntersectionStruct<T, T>
+              : UnionStruct<T, T> | IntersectionStruct<T, T>)
+
+export type Struct<T = any> =
+    | (T extends Generics.PrimitiveType
+          ? T extends undefined
+              ? UndefinedStruct
+              : T extends null
+                ? NullStruct
+                : T extends boolean
+                  ? BooleanStruct<T>
+                  : T extends bigint
+                    ? BigIntStruct<T>
+                    : T extends number
+                      ? NumberStruct<T>
+                      : T extends string
+                        ? StringStruct<T>
+                        : T extends symbol
+                          ? SymbolStruct
+                          : PrimitiveStruct<T> | AnyStruct | EnumStruct<T>
+          : never)
+    | (T extends (infer _)[]
+          ? never
+          : T extends Generics.PrimitiveType
+            ? never
+            : T extends object
+              ? ObjectStruct<T>
+              : never)
+    | (T extends (infer U)[] ? ArrayStruct<U> : never)
+
+export type StructType =
+    | PrimitiveStruct<Generics.PrimitiveType>
+    | AnyStruct
+    | UndefinedStruct
+    | NullStruct
+    | BooleanStruct
+    | NumberStruct
+    | BigIntStruct
+    | StringStruct
+    | SymbolStruct
+    | UnionOrIntersectionPartialStruct<any, any>
+    | EnumStruct<Generics.PrimitiveType>
+    | UnionStruct<any>
+    | IntersectionStruct<any>

--- a/src/validators/schema/types/v3/index.ts
+++ b/src/validators/schema/types/v3/index.ts
@@ -1,0 +1,356 @@
+import type Generics from '../../../../Generics/index.ts'
+import type { ConstructorSignature, TypeGuard } from '../../../../TypeGuards/types/index.ts'
+import type { ArrayRule } from '../../../rules/Array/index.ts'
+import type { NumberRule } from '../../../rules/Number/index.ts'
+import type { RecordRule } from '../../../rules/Record/index.ts'
+import type { StringRule } from '../../../rules/String/index.ts'
+import type { StandardSchemaV1 } from '../../../standard-schema/types.ts'
+import type {
+    All as AllRules,
+    Custom as CustomRule,
+    RuleStruct,
+} from '../../../rules/types/index.ts'
+
+export type BaseStruct<T extends Generics.BaseTypes | 'custom', U> = {
+    type: T
+    schema: TypeGuard<U>
+    optional: boolean
+}
+
+export namespace V3 {
+    export type RequiredPartialStruct = {
+        optional: false
+    }
+    export type OptionalPartialStruct = {
+        optional: true
+    }
+
+    export type RequirefyStruct<S extends Struct> = Omit<S, 'optional'> & RequiredPartialStruct
+    export type OptionalizeStruct<S extends Struct> = Omit<S, 'optional'> & OptionalPartialStruct
+
+    export type PrimitiveStruct<
+        Rules extends CustomRule<any[], string, Generics.PrimitiveType> = CustomRule<
+            any[],
+            string,
+            Generics.PrimitiveType
+        >,
+    > = BaseStruct<'primitive', Generics.PrimitiveType> & WithRulesStruct<Rules>
+    export type AnyStruct<
+        Rules extends CustomRule<any[], string, any> = CustomRule<any[], string, any>,
+    > = BaseStruct<'any', any> & WithRulesStruct<Rules>
+    export type UndefinedStruct<
+        Rules extends CustomRule<any[], string, undefined> = CustomRule<any[], string, undefined>,
+    > = BaseStruct<'undefined', undefined> & WithRulesStruct<Rules>
+    export type NullStruct<
+        Rules extends CustomRule<any[], string, null> = CustomRule<any[], string, null>,
+    > = BaseStruct<'null', null> & WithRulesStruct<Rules>
+    export type BooleanStruct<
+        Rules extends CustomRule<any[], string, boolean> = CustomRule<any[], string, boolean>,
+    > = BaseStruct<'boolean', boolean> & WithRulesStruct<Rules>
+    export type NumberStruct<
+        Rules extends CustomRule<any[], string, number> = CustomRule<any[], string, number>,
+    > = BaseStruct<'number', number> & WithRulesStruct<NumberRule | Rules>
+    export type BigIntStruct<
+        Rules extends CustomRule<any[], string, bigint> = CustomRule<any[], string, bigint>,
+    > = BaseStruct<'bigint', bigint> & WithRulesStruct<NumberRule | Rules>
+    export type StringStruct<
+        Rules extends CustomRule<any[], string, string> = CustomRule<any[], string, string>,
+    > = BaseStruct<'string', string> & WithRulesStruct<StringRule | Rules>
+    export type SymbolStruct<
+        Rules extends CustomRule<any[], string, symbol> = CustomRule<any[], string, symbol>,
+    > = BaseStruct<'symbol', symbol> & WithRulesStruct<Rules>
+
+    export type WithRulesStruct<Rule extends AllRules<any[], string, any>> = {
+        rules: RuleStruct<Rule>[]
+    }
+
+    export type MapToStructs<Types extends any[]> = Types extends []
+        ? []
+        : Types extends [infer T0, ...infer TRest]
+          ? [GenericStruct<T0, true> | CustomStruct<T0> | StructType, ...MapToStructs<TRest>]
+          : (GenericStruct<any, true> | CustomStruct<any> | StructType)[]
+
+    export type TUnion<Types extends any[]> = Types extends []
+        ? never
+        : Types extends [infer T0, ...infer TRest]
+          ? TRest extends []
+              ? T0
+              : T0 | TUnion<TRest>
+          : any
+    export type TIntersection<Types extends any[]> = Types extends []
+        ? never
+        : Types extends [infer T0, ...infer TRest]
+          ? TRest extends []
+              ? T0
+              : T0 & TIntersection<TRest>
+          : any
+
+    export type ExactExtends<TSource, TCompare, TValueIfTrue = TSource, TValueIfFalse = never> =
+        Exclude<TSource, TCompare> extends never ? TValueIfTrue : TValueIfFalse
+    export type IsExactExtension<TSource, TCompare> = ExactExtends<TSource, TCompare, true, false>
+
+    type UnionOrIntersectionPartialStruct<Types extends any[]> = {
+        types: MapToStructs<Types>
+    }
+
+    type EnumPartialStruct<T extends Generics.PrimitiveType = any> = {
+        types: ((
+            | StringStruct
+            | NumberStruct
+            | BigIntStruct
+            | BooleanStruct
+            | SymbolStruct
+            | NullStruct
+            | UndefinedStruct
+        ) &
+            Generics.WrapInObject<Generics.GetPrimitiveTag<T>, 'type'> &
+            RequiredPartialStruct)[]
+    }
+
+    export type EnumStruct<
+        T extends Generics.PrimitiveType = any,
+        Rules extends CustomRule<any[], string, Generics.PrimitiveType> = CustomRule<
+            any[],
+            string,
+            Generics.PrimitiveType
+        >,
+    > = BaseStruct<'enum', T> & EnumPartialStruct<T> & WithRulesStruct<Rules>
+
+    export type UnionStruct<
+        Types extends any[],
+        Rules extends CustomRule<any[], string, any> = CustomRule<any[], string, any>,
+    > = BaseStruct<'union', TUnion<Types>> &
+        UnionOrIntersectionPartialStruct<Types> &
+        WithRulesStruct<Rules>
+
+    export type IntersectionStruct<
+        Types extends any[],
+        Rules extends CustomRule<any[], string, any> = CustomRule<any[], string, any>,
+    > = BaseStruct<'intersection', TIntersection<Types>> &
+        UnionOrIntersectionPartialStruct<Types> &
+        WithRulesStruct<Rules>
+
+    export type ObjectTree<T extends {}> = {
+        tree: {
+            [K in keyof T]: V3.GenericStruct<T[K]> | V3.StructType
+        }
+    }
+
+    export type ObjectStruct<
+        T extends {},
+        Rules extends CustomRule<any[], string, T> = CustomRule<any[], string, T>,
+    > = BaseStruct<'object', T> & ObjectTree<T> & WithRulesStruct<Rules>
+
+    export type ClassInstanceRef<T extends {}, ClassNameStr = string> = {
+        constructor: ConstructorSignature<T>
+        className: ClassNameStr
+    }
+
+    export type ClassInstanceStruct<
+        T extends {},
+        ClassNameStr = string,
+        Rules extends CustomRule<any[], string, T> = CustomRule<any[], string, T>,
+    > = BaseStruct<'object', T> &
+        // biome-ignore lint/complexity/noBannedTypes: {} as generic constraint for non-nullish is idiomatic TS
+        ObjectTree<{}> &
+        ClassInstanceRef<T, ClassNameStr> &
+        WithRulesStruct<Rules>
+
+    export type ArrayEntries<U> = {
+        entries: V3.GenericStruct<U>
+    }
+
+    export type ArrayStruct<
+        U,
+        Rules extends CustomRule<any[], string, U[]> = CustomRule<any[], string, U[]>,
+    > = BaseStruct<'object', U[]> & ArrayEntries<U> & WithRulesStruct<ArrayRule | Rules>
+
+    export type RecordMetadata<T extends {}> = {
+        keyMetadata:
+            | V3.StringStruct
+            | V3.NumberStruct
+            | V3.SymbolStruct
+            | V3.EnumStruct<PropertyKey>
+            | (V3.CustomStruct<string> & { kind: 'string' })
+        valueMetadata: V3.GenericStruct<T[keyof T]> | V3.StructType
+    }
+
+    export type RecordStruct<
+        K extends PropertyKey = string,
+        T = any,
+        Rules extends CustomRule<any[], string, Record<K, T>> = CustomRule<
+            any[],
+            string,
+            Record<K, T>
+        >,
+    > = BaseStruct<'record', Record<K, T>> &
+        RecordMetadata<Record<K, T>> &
+        WithRulesStruct<RecordRule | Rules>
+
+    export type TupleMetadata<T extends readonly [...any]> = {
+        elements: TupleToStructMap<T>
+    }
+    export type TupleToTypeGuardMap<T extends readonly [...any]> = T extends readonly [
+        infer T0,
+        ...infer TRest,
+    ]
+        ? readonly [TypeGuard<T0>, ...TupleToTypeGuardMap<TRest>]
+        : T
+
+    export type TupleToStructMap<T extends readonly [...any]> = T extends readonly [
+        infer T0,
+        ...infer TRest,
+    ]
+        ? readonly [V3.GenericStruct<T0>, ...TupleToStructMap<TRest>]
+        : T
+
+    export type TypeGuardTupleUnwrap<T extends readonly [...any]> = T extends readonly [
+        infer T0,
+        ...infer TRest,
+    ]
+        ? T0 extends TypeGuard<infer U>
+            ? [U, ...TypeGuardTupleUnwrap<TRest>]
+            : T0 extends StandardSchemaV1<infer U, any>
+              ? [U, ...TypeGuardTupleUnwrap<TRest>]
+              : [T0, ...TypeGuardTupleUnwrap<TRest>]
+        : T
+
+    export type TupleStruct<
+        T extends readonly [...any],
+        Rules extends CustomRule<any[], string, T> = CustomRule<any[], string, T>,
+    > = BaseStruct<'tuple', T> & TupleMetadata<T> & WithRulesStruct<Rules>
+
+    export type CustomStruct<
+        T,
+        Rules extends CustomRule<any[], string, T> = CustomRule<any[], string, T>,
+    > = Prettify<
+        BaseStruct<'custom', T> & {
+            /** kind of the custom struct's value mapped */
+            kind?: string
+            /** context metadata for the custom struct */
+            context?: Record<string, any> | null
+        } & WithRulesStruct<Rules>
+    >
+
+    export type GenericStruct<
+        T = any,
+        UnionOrIntersection extends 'union' | 'intersection' | true | false = true,
+        Rules extends CustomRule<any[], string, any> = CustomRule<any[], string, any>,
+        // biome-ignore lint/complexity/noBannedTypes: Function used in conditional type for type-level dispatch
+    > = T extends Function
+        ? AnyStruct<Rules> & { schema: TypeGuard<T> }
+        :
+              | Struct<T, Rules>
+              | CustomStruct<T, Rules>
+              | (UnionOrIntersection extends false
+                    ? never
+                    : UnionOrIntersection extends 'union'
+                      ? T extends any[]
+                          ? UnionStruct<T, Rules>
+                          : never
+                      : UnionOrIntersection extends 'intersection'
+                        ? T extends any[]
+                            ? IntersectionStruct<T, Rules>
+                            : never
+                        : T extends any[]
+                          ? UnionStruct<T, Rules> | IntersectionStruct<T, Rules>
+                          : never)
+
+    export type AsPrimitiveStruct<
+        T extends Generics.PrimitiveType,
+        Rules extends CustomRule<any[], string, Generics.PrimitiveType> = CustomRule<
+            any[],
+            string,
+            Generics.PrimitiveType
+        >,
+    > =
+        IsExactExtension<Generics.PrimitiveType, T> extends true
+            ? PrimitiveStruct<Rules>
+            : IsExactExtension<T, undefined> extends true
+              ? UndefinedStruct<Rules>
+              : IsExactExtension<T, null> extends true
+                ? NullStruct<Rules>
+                : IsExactExtension<T, boolean> extends true
+                  ? BooleanStruct<Rules>
+                  : IsExactExtension<T, bigint> extends true
+                    ? BigIntStruct<Rules>
+                    : IsExactExtension<T, number> extends true
+                      ? NumberStruct<Rules>
+                      : IsExactExtension<T, string> extends true
+                        ? StringStruct<Rules>
+                        : IsExactExtension<T, symbol> extends true
+                          ? SymbolStruct<Rules>
+                          : never
+
+    export type Struct<
+        T = any,
+        Rules extends CustomRule<any[], string, any> = CustomRule<any[], string, any>,
+    > = T extends Generics.PrimitiveType
+        ? EnumStruct<T, Rules> | IsExactExtension<T, undefined> extends true
+            ? UndefinedStruct<Rules>
+            : IsExactExtension<T, null> extends true
+              ? NullStruct<Rules>
+              : IsExactExtension<T, boolean> extends true
+                ? BooleanStruct<Rules>
+                : IsExactExtension<T, bigint> extends true
+                  ? BigIntStruct<Rules>
+                  : IsExactExtension<T, number> extends true
+                    ? NumberStruct<Rules>
+                    : IsExactExtension<T, string> extends true
+                      ? StringStruct<Rules>
+                      : IsExactExtension<T, symbol> extends true
+                        ? SymbolStruct<Rules>
+                        : never
+        : T extends readonly [...any]
+          ? TupleStruct<T, Rules>
+          : T extends (infer U)[]
+            ? ArrayStruct<U, Rules>
+            : // biome-ignore lint/complexity/noBannedTypes: {} used in conditional type for object detection
+              T extends {}
+              ?
+                    | ObjectStruct<T, Rules>
+                    | RecordStruct<keyof T, T[keyof T], Rules>
+                    | ClassInstanceStruct<T, Rules>
+              : never
+
+    export type StructType<
+        Rules extends CustomRule<any[], string, any> = CustomRule<any[], string, any>,
+    > =
+        | PrimitiveStruct<Rules>
+        | AnyStruct<Rules>
+        | UndefinedStruct<Rules>
+        | NullStruct<Rules>
+        | BooleanStruct<Rules>
+        | NumberStruct<Rules>
+        | BigIntStruct<Rules>
+        | StringStruct<Rules>
+        | SymbolStruct<Rules>
+        | EnumStruct<Generics.PrimitiveType, Rules>
+        | UnionStruct<any[], Rules>
+        | IntersectionStruct<any[], Rules>
+        | ObjectStruct<any, Rules>
+        | ArrayStruct<any, Rules>
+        | RecordStruct<string, any, Rules>
+        | ClassInstanceStruct<any, Rules>
+        | TupleStruct<any[], Rules>
+        | CustomStruct<any, Rules>
+
+    export type FromStruct<T extends Struct<any>> = T extends Struct<infer U> ? U : never
+    export type FromUnionStruct<T extends UnionStruct<any>> =
+        T extends UnionStruct<infer U> ? TUnion<U> : never
+    export type FromIntersectionStruct<T extends IntersectionStruct<any>> =
+        T extends IntersectionStruct<infer U> ? TIntersection<U> : never
+
+    export type FromRecordStruct<T extends RecordStruct<any, any>> =
+        T extends RecordStruct<infer K, infer T> ? Record<K, T> : never
+
+    export type FromClassInstanceStruct<T extends ClassInstanceStruct<any>> =
+        T extends ClassInstanceStruct<infer U> ? U : never
+
+    export type FromTupleStruct<T extends TupleStruct<any>> =
+        T extends TupleStruct<infer U> ? U : never
+}
+
+export type TUnion<Types extends any[]> = V3.TUnion<Types>
+export type TIntersection<Types extends any[]> = V3.TIntersection<Types>
+export type TypeGuardTupleUnwrap<T extends readonly [...any]> = V3.TypeGuardTupleUnwrap<T>

--- a/src/validators/types/ValidateReturn.ts
+++ b/src/validators/types/ValidateReturn.ts
@@ -1,0 +1,10 @@
+import type ValidationError from '../ValidationError.ts'
+import type { ValidationErrors } from '../ValidationErrors.ts'
+
+export type ValidateReturn<T> =
+    | T
+    | ValidationErrors<
+          | ValidationError<unknown, T>
+          | ValidationError<unknown, T[Extract<keyof T, string>], Extract<keyof T, string>, T>
+          | ValidationError
+      >


### PR DESCRIPTION
## Summary
- Extract 11 inline schema type definitions from builder files into dedicated type files under `src/validators/schema/types/` (BooleanSchema, NullSchema, UndefinedSchema, SymbolSchema, AnySchema, PrimitiveSchema, EnumSchema, ObjectSchema, TupleSchema, UnionSchema, IntersectionSchema)
- Add `GetSchema<T>` recursive type helper that maps TypeScript types to their corresponding `FluentSchema` result types
- Re-export all new schema types, `ValidateReturn`, and rule types (`Custom`, `CustomFactory`, `Rule`, `CreateRuleArgs`) from the types hub
- Replace `export * from ./v3/index.ts` wildcard with explicit allowlist to prevent internal V3 composition types from leaking into the public API
- Replace `export * from ./types/index.ts` wildcard in rules barrel with explicit type allowlist to prevent `CUSTOM_RULE_BRAND` (runtime symbol) and `RuleStruct` (internal dispatch type) from reaching the public API
- Remove `Optionalize<T>`, `GetSchemaStruct<T>`, and `RuleStruct<Rule>` from public exports (internal-only, no external consumers)
- Fix `GetSchema` edge cases: `any` guard, `unknown`/`void`/`never` branches, Record detection for all key types

## Exports now available from `@srhenry/type-utils`

| Type | Description |
|------|-------------|
| `GetSchema<T>` | Maps TS type → FluentSchema result type |
| `ValidateReturn<T>` | Return type of schema validation |
| `BooleanSchema`, `NullSchema`, `UndefinedSchema`, `SymbolSchema`, `AnySchema`, `PrimitiveSchema` | Simple schema builder types |
| `EnumSchema`, `ObjectSchema`, `TupleSchema`, `UnionSchema`, `IntersectionSchema` | Complex schema builder types |
| `TupleSchemaEntry`, `UnionSchemaEntry`, `IntersectionSchemaEntry` | Entry types for composite schemas |
| `GetUnionEntryTypes`, `GetIntersectionEntryTypes` | Helper types for union/intersection entry unwrapping |
| `Custom`, `CustomFactory`, `Rule`, `CreateRuleArgs` | Rule types |
| `V1`, `V2`, `V3` | Historical version namespaces |
| `BaseStruct`, `TUnion`, `TIntersection`, `TypeGuardTupleUnwrap` | V3 flat exports (explicit allowlist) |
| `GenericStruct`, `ObjectStruct`, `Struct`, `StructType` | Top-level V3 aliases (backward compat) |

## Key change: V3 wildcard → explicit allowlist

The barrel file `src/validators/schema/types/index.ts` previously used `export * from './v3/index.ts'`, which re-exported every type inside the V3 namespace flat — including ~25 internal composition types that consumers should never import directly:

`RequiredPartialStruct`, `OptionalPartialStruct`, `RequirefyStruct`, `OptionalizeStruct`, `WithRulesStruct`, `MapToStructs`, `ExactExtends`, `IsExactExtension`, `ObjectTree`, `ClassInstanceRef`, `ArrayEntries`, `RecordMetadata`, `TupleMetadata`, `TupleToTypeGuardMap`, `TupleToStructMap`, `AsPrimitiveStruct`, `FromUnionStruct`, `FromIntersectionStruct`, `FromRecordStruct`, `FromClassInstanceStruct`, `FromTupleStruct`

These types are still accessible to internal consumers via the `V3` namespace (e.g. `V3.RequiredPartialStruct`), but they are no longer re-exported as bare names from the barrel. Only the 4 top-level flat exports from `v3/index.ts` are explicitly allowed through: `BaseStruct`, `TUnion`, `TIntersection`, `TypeGuardTupleUnwrap`.

**Note:** The V3 concrete struct types (`V3.StringStruct`, `V3.NumberStruct`, etc.) were never available as bare flat imports — they were always inside the V3 namespace on the original `developer` branch. This PR does not change that.

## Key change: Rules barrel wildcard → explicit allowlist

Similarly, `src/validators/rules/index.ts` previously used `export * from ./types/index.ts`, which re-exported `CUSTOM_RULE_BRAND` (a runtime `unique symbol` used internally for type branding) and `RuleStruct<Rule>` (an internal dispatch type). These are now excluded from the public API by replacing the wildcard with an explicit type allowlist. Internal consumers still import these directly from `./types/index.ts`.

## Key change: GetSchema edge cases

- **`GetSchema<any>`**: Previously mis-mapped to `FluentSchema<string, StringSchemaRules>` because `any` distributes through conditionals. Now uses the `0 extends (1 & T)` guard pattern to detect `any` early, correctly resolving to `FluentSchema<any>`.
- **`GetSchema<unknown>`**: Previously returned `never` because `unknown` fails all conditional branches. Now has an explicit branch mapping to `FluentSchema<any>`.
- **`GetSchema<void>`**: Added explicit branch mapping to `FluentSchema<any>`. Previously fell through to `never`.
- **`GetSchema<never>`**: Explicitly returns `never` — intentional, since `never` inputs should produce `never` outputs.
- **`GetSchema<Record<K, V>>`**: Previously used `PropertyKey extends keyof T` which **never matched** any Record type because `symbol` doesn't extend `string` or `number`. All Records silently fell through to the "specific object" branch, losing `RecordSchemaRules` (including `.nonEmpty()`). Now uses per-key-type checks: `string extends keyof T`, `number extends keyof T`, `symbol extends keyof T` — correctly detecting Records with any broad key type.
- **Unreachable `never` fallbacks**: The broad `string`/`number` detection branches (`[string] extends [T]`, `[number] extends [T]`) have documented `never` fallbacks for cases where `[K] extends [T]` is true but `T extends K` is false. These are unreachable because the only such types are `any` and `unknown`, both caught earlier, but the fallbacks are safety nets documented for future maintainers.

## Test Plan
- [x] `yarn tsc -p tsconfig.json --noEmit` — all type assertions pass
- [x] `yarn tsc -p tsconfig.esm.json --noEmit` — ESM typecheck passes
- [x] `yarn tsc -p tsconfig.cjs.json --noEmit` — CJS typecheck passes
- [x] `yarn test` — 382 passed, 1 skipped
- [x] `yarn build` — ESM + CJS outputs generated
- [x] `yarn check:fix` — lint + format clean
- [x] `yarn circular-dependencies` — 0 circular deps
- [x] All new types importable from `@srhenry/type-utils` entry
- [x] `GetSchema` type-level assertions compile correctly (all cases including `any`, `unknown`, `void`, `never`, `Record<string,V>`, `Record<number,V>`, `Record<symbol,V>`, function, Date)
- [x] Strict Record assertions verify `RecordSchemaRules` is present (not `{}`), ensuring `.nonEmpty()` method is available
- [x] Internal V3 types no longer leak as flat exports
- [x] `CUSTOM_RULE_BRAND` and `RuleStruct` no longer in public API