### PR TITLE
chore(release): bump version to 0.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@srhenry/type-utils",
-    "version": "0.8.4",
+    "version": "0.8.5",
     "description": "Type utilities for Typescript and also Javascript",
     "type": "module",
     "main": "./dist/cjs/index.js",


### PR DESCRIPTION
## Summary

Patch release bumping `@srhenry/type-utils` from `0.8.4` to `0.8.5`.

This PR prepares the release commit on `master`. Once merged, a signed tag `v0.8.5` will be cut from the resulting master tip, and a draft GitHub release will be opened (the draft will be manually published to trigger `npm publish --provenance` via CI).

## What this release contains

33 commits since `v0.8.4` (last tag at `937fd6a0`).

### Security Fixes (transitive deps)

- **`jsdiff` parsePatch infinite loop** — patch via `resolutions` for CVE-2026-24001 / GHSA-73rr-hh4g-fpgx (commit `133a9cb7`)
- **`ajv` ReDoS vulnerability** — patch via `resolutions` for CVE-2025-69873 / GHSA-2g4f-4pwh-qvx6 (commit `1fe83df7`)

### Toolchain upgrade

- **TypeScript 6.0.3 → 7.0.2** (commit `22a908ff`, PR #72).
  - `peerDependencies.typescript` stays `\">=5.8\"` — TS 7.0.2 satisfies it, so consumers on TS 5.8+ and 6.x are unaffected.
  - `experimentalDecorators: true` is still load-bearing for the three stage-2 decorator files (`src/TypeGuards/TypeErrors.ts`, `src/validators/SchemaValidator.ts`, `src/validators/ValidationError.ts`). Migration to stage-3 decorators tracked separately as `migrate-stage2-to-stage3-decorators` in `TASKS.md`.
  - Yarn resolution `madge/**/typescript: 5.8.3` retained as load-bearing — TS 7.0 deliberately omits the programmatic Compiler API (`ts.sys`, `ts.readConfigFile`), which `madge` requires at `madge/lib/api.js:52`.

### Dev dependency refreshes

- `@biomejs/biome` `2.4.16` → `^2.5.0` (now `2.5.3`)
  - `biome.json` migrated from `recommended` field to `preset` schema (PR #69, commit `02a5283e`)
  - 77 `// biome-ignore lint/nursery/{noShadow,noUnnecessaryConditions}` suppression comments across 48 src files updated to `lint/suspicious/...` (nursery group was reorganized in Biome 2.5.x)
- `prettier` `3.8.3` → `^3.9.5` (now `3.9.5`)
  - 11 source files reformatted per Prettier 3.9.x line-fit improvements (PR #68, commit `8a8ba8ae`)
- `vitest` / `@vitest/coverage-v8` `4.1.8` → `^4.1.8` (now `4.1.10`)
- `@types/node` `25.9.2` → `^25.9.2` (now `25.9.5`; caret blocks future 26.x major)
- `typedoc` `0.28.19` → `^0.28.19` (now `0.28.20`; caret on 0.x stays within `0.28.x`)
- Dev dependencies loosened from exact pins (introduced as a TS7 upgrade mitigation) back to caret ranges (PR #73, commit `548f8d6d`)

### Internal / Hygiene

- Worktree convention in `AGENTS.md` changed from `/tmp/<repo-name>-<topic>` to `.worktree/<topic>` (commit `c996009d`) and `.worktree/` added to `.gitignore`
- `master` / `developer` realignment (commits `c7f91153`, `a87bf71c`) — 3 dependabot PRs that landed directly on `master` (#67 `@types/node`, #70 `webpack-cli`, #71 `webpack`) were merged into `developer`; `developer` was then merged back to `master`
- `TASKS.md` cleanup — completed follow-up tasks removed; stale `Blocked by: ts7-upgrade` references cleaned up (commit `b3d93453`)
- Worktree-convention-local task removed (commit `ddbe697b`)

## What this release does NOT contain

- **No new user-facing APIs** (no new Schema types, no new validation rules, no new Standard Schema interop functions, no new utility types)
- **No deprecations**
- **No breaking changes**
- **No behavioral changes** to any public API surface

## Why no README update

Per `workflows/release/release-readme-prompt.md`:
> Do NOT add bug fix notes, changelog entries, or per-version callouts to the README — these belong in CHANGELOG.md or GitHub Release Notes.
> Do NOT document internal tooling, CI/CD, or build pipeline changes — these are not user-facing APIs.

This release has no new user-facing APIs and the public API surface is unchanged. The README already documents the current public API correctly.

## Validation gate (all green on the release commit)

| Gate | Command | Result |
|------|---------|--------|
| Typecheck | `yarn tsc -p tsconfig.json --noEmit` | ✅ 0 errors |
| Lint + format | `yarn run check` | ✅ Biome: 0 errors / 1074 warnings (baseline); prettier: `All matched files use Prettier code style` |
| Tests | `yarn test` | ✅ 406 passed, 1 skipped (no regression) |
| Build | `yarn build:clean` | ✅ ESM + CJS + declarations succeeded |
| Circular deps | `yarn circular-dependencies` | ✅ no circular deps |

## Post-merge plan

1. Squash-merge this PR to `master`
2. Delete feature branch on both remotes
3. Cut a GPG-signed annotated tag `v0.8.5` from the resulting master commit
4. Push tag to both remotes (`origin`, `mirror-gitlab`)
5. Run `yarn build:clean && npm pack` locally → rename tarball to `type-utils-0.8.5.tgz` (per AGENTS.md tarball naming convention — never the scoped package name)
6. Create a DRAFT GitHub release with enriched release notes (grouped: Security Fixes + Toolchain + DevDep refreshes + Internal) and attach the tarball
7. Delete the local tarball immediately (per AGENTS.md \"Tarball cleanup\" rule)
8. **STOP** — the draft will be reviewed and manually published by the maintainer. Publishing triggers `npm publish --provenance` via the `publish-npm.yml` CI (OIDC, no NPM_TOKEN secret required).

## Semver justification

Pre-1.0 per the release pipeline: `0.x.x` — minor = new features (possibly breaking), **patch = bug fixes**. This release contains only:
- transitive CVE patches (bug-fix category),
- internal toolchain migration (TS7 + biome + prettier), and
- dev dependency refreshes.

No new user-facing features. **Patch bump is correct (`0.8.4` → `0.8.5`).**